### PR TITLE
refactor: expose shutdown() to forcefully close connections

### DIFF
--- a/src/common/src/aws/sdk/kotlin/crt/http/HttpClientConnection.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/http/HttpClientConnection.kt
@@ -28,4 +28,12 @@ public interface HttpClientConnection : Closeable {
      *          request/response, but must be closed by the user thread making this request when it's done.
      */
     public fun makeRequest(httpReq: HttpRequest, handler: HttpStreamResponseHandler): HttpStream
+
+    /**
+     * Forcefully close the connection
+     *
+     * NOTE: connections are vended via [HttpClientConnectionManager], [close] will just return the connection to the pool
+     * and potentially be re-used.
+     */
+    public fun shutdown()
 }

--- a/src/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionJVM.kt
+++ b/src/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionJVM.kt
@@ -17,7 +17,7 @@ internal class HttpClientConnectionJVM constructor(internal val jniConn: HttpCli
         return HttpStreamJVM(jniStream)
     }
 
-    override fun close() {
-        jniConn.close()
-    }
+    override fun close() = jniConn.close()
+
+    override fun shutdown() = jniConn.shutdown()
 }


### PR DESCRIPTION
*Issue #, if available:*
support for: https://github.com/awslabs/aws-sdk-kotlin/pull/178

*Description of changes:*
Expose `shutdown()` which forcefully closes the connection

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
