### PR TITLE
feat: enable signing for published artifacts

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -4,7 +4,7 @@
  */
 
 apply plugin: 'maven-publish'
-
+apply plugin: 'signing'
 
 publishing {
     repositories {
@@ -40,6 +40,16 @@ publishing {
                 developerConnection = "scm:git:ssh://github.com/awslabs/aws-crt-kotlin.git"
                 url = "https://github.com/awslabs/aws-crt-kotlin"
             }
+        }
+    }
+
+    if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+        signing {
+            useInMemoryPgpKeys(
+                    (String) project.property("signingKey"),
+                    (String) project.property("signingPassword")
+            )
+            sign(publications)
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:* Enable PGP key signing of artifacts, necessary before uploading to Maven Central.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
