### PR TITLE
feat: implement Nexus publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import java.util.Properties
 
 plugins {
     kotlin("multiplatform")
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
 val sdkVersion: String by project
@@ -95,6 +96,21 @@ jvmTest.apply {
     }
 
     useJUnitPlatform()
+}
+
+if (project.hasProperty("sonatypeUsername") && project.hasProperty("sonatypePassword")) {
+    apply(plugin = "io.github.gradle-nexus.publish-plugin")
+
+    nexusPublishing {
+        repositories {
+            create("awsNexus") {
+                nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+                username.set(project.property("sonatypeUsername") as String)
+                password.set(project.property("sonatypePassword") as String)
+            }
+        }
+    }
 }
 
 apply(from = rootProject.file("gradle/publish.gradle"))

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -6,6 +6,12 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+// No docs will be published for CRT since it's only used internally to the SDK.
+tasks.register("javadocJar", Jar) {
+    archiveClassifier.set("javadoc")
+    from()
+}
+
 publishing {
     repositories {
         maven { name = "testLocal"; url = "$rootProject.buildDir/m2" }
@@ -20,25 +26,31 @@ publishing {
     }
 
     publications.all {
-        pom {
-            url = "https://github.com/awslabs/aws-crt-kotlin"
-            licenses {
-                license {
-                    name = "The Apache License, Version 2.0"
-                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                }
-            }
-            developers {
-                developer {
-                    id = "aws-crt-kotlin"
-                    name = "AWS SDK Kotlin Team"
-                    // TODO - team email?
-                }
-            }
-            scm {
-                connection = "scm:git:git://github.com/awslabs/aws-crt-kotlin.git"
-                developerConnection = "scm:git:ssh://github.com/awslabs/aws-crt-kotlin.git"
+        project.afterEvaluate {
+            pom {
+                name = project.name
+                description = project.description
                 url = "https://github.com/awslabs/aws-crt-kotlin"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "aws-crt-kotlin"
+                        name = "AWS SDK Kotlin Team"
+                        // TODO - team email?
+                    }
+                }
+                scm {
+                    connection = "scm:git:git://github.com/awslabs/aws-crt-kotlin.git"
+                    developerConnection = "scm:git:ssh://github.com/awslabs/aws-crt-kotlin.git"
+                    url = "https://github.com/awslabs/aws-crt-kotlin"
+                }
+
+                artifact(tasks["javadocJar"])
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:*

Implements publishing to Nexus (and thus onto Maven Central) by use of the [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin). A few things had to be cleaned up here to pass the scanning required for staging repos:
* Changed POM publishing configuration to run after full evaluation and explicitly configured name and description (all POMs are required to have a name and description)
* Add generation of an empty Javadoc JAR (all artifacts are required to include Javadoc JARs). This is possibly permanent since there are no current plans for support documentation for the CRT package.

This change is based off of awslabs/aws-sdk-kotlin#272

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.