### PR TITLE
Fix IDE build error in aws-sdk-kotlin/examples

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
 
     jvm {
         attributes {
-            attribute(
+            attribute<org.gradle.api.attributes.java.TargetJvmEnvironment>(
                 TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
                 objects.named(TargetJvmEnvironment.STANDARD_JVM)
             )


### PR DESCRIPTION
STR:
* Add following to aws-sdk-kotlin/local.properties:
  `compositeProjects=../smithy-kotlin,../aws-crt-kotlin,examples`
* Build project in Intellij
* Observe build failures similar to:
```
* What went wrong:
Script compilation errors:
 
  Line 38:             attribute(
                       ^ Not enough information to infer type variable T
 
  Line 39:                 TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
                           ^ Unresolved reference: TargetJvmEnvironment
...
```

I'm not sure if this change should be merged or not.  Ideally we could treat the examples tree as source in the IDE but this may just be a bug in intellij and not worth complicating our build scripts.  OTOH it's a minor addition.

*Issue #, if available:* N/A

*Description of changes:*
* Specify generic type to resolve build error in aws-sdk-kotlin/examples module


NOTE: command-line build (`./gradlew assemble`) from `aws-sdk-kotlin` does not seem to exhibit the issue, only w/ IDE builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
