### PR TITLE
fix: utilize endpoint ports

### DIFF
--- a/elasticurl/src/commonMain/kotlin/Application.kt
+++ b/elasticurl/src/commonMain/kotlin/Application.kt
@@ -71,7 +71,7 @@ fun main(args: Array<String>) {
         headers {
             // manually add a user-agent and host header
             if (!contains("User-Agent")) append("User-Agent", "elasticurl_kotlin 1.0, Powered by the AWS Common Runtime.")
-            if (!contains("Host")) append("Host", uri.host)
+            if (!contains("Host")) append("Host", uri.hostAndPort)
         }
     }
 

--- a/src/common/src/aws/sdk/kotlin/crt/io/Uri.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/io/Uri.kt
@@ -65,6 +65,37 @@ public data class Uri(
      */
     val port: Int = specifiedPort.takeUnless { it == DEFAULT_SCHEME_PORT } ?: scheme.defaultPort
 
+    /**
+     * The authority of the URI (as defined by
+     * [RFC 3986 § 3.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2)), i.e., the userinfo, host, and port
+     * portion.
+     */
+    val authority: String
+        get() = buildString {
+            userInfo?.let { userinfo ->
+                if (userinfo.username.isNotBlank()) {
+                    append(userinfo.username)
+                    if (userinfo.password.isNotBlank()) {
+                        append(":${userinfo.password}")
+                    }
+                    append("@")
+                }
+            }
+
+            append(hostAndPort)
+        }
+
+    /**
+     * The host and port of the URI (e.g., "server.com:1234").
+     */
+    val hostAndPort: String
+        get() = buildString {
+            append(host)
+            if (specifiedPort != DEFAULT_SCHEME_PORT && specifiedPort != scheme.defaultPort) {
+                append(":$specifiedPort")
+            }
+        }
+
     public companion object {
         /**
          * Build a URI
@@ -80,20 +111,7 @@ public data class Uri(
     override fun toString(): String = buildString {
         append(scheme.name)
         append("://")
-        userInfo?.let { userinfo ->
-            if (userinfo.username.isNotBlank()) {
-                append(userinfo.username)
-                if (userinfo.password.isNotBlank()) {
-                    append(":${userinfo.password}")
-                }
-                append("@")
-            }
-        }
-
-        append(host)
-        if (specifiedPort != DEFAULT_SCHEME_PORT && specifiedPort != scheme.defaultPort) {
-            append(":$specifiedPort")
-        }
+        append(authority)
 
         if (path.isNotBlank()) {
             append("/")

--- a/src/common/test/aws/sdk/kotlin/crt/auth/signing/SigningTest.kt
+++ b/src/common/test/aws/sdk/kotlin/crt/auth/signing/SigningTest.kt
@@ -31,7 +31,7 @@ class SigningTest : CrtTest() {
         val bodyLen = bodyBytes?.size ?: 0
 
         headers {
-            append("Host", uri.host)
+            append("Host", uri.hostAndPort)
             append("Content-Length", bodyLen.toString())
         }
 

--- a/src/common/test/aws/sdk/kotlin/crt/http/HttpClientTest.kt
+++ b/src/common/test/aws/sdk/kotlin/crt/http/HttpClientTest.kt
@@ -84,7 +84,7 @@ abstract class HttpClientTest : CrtTest() {
                     val request = HttpRequest.build {
                         method = verb
                         encodedPath = uri.path
-                        headers.append("Host", uri.host)
+                        headers.append("Host", uri.hostAndPort)
                         if (bodyBytes != null) {
                             headers.append("Content-Length", bodyBytes.size.toString())
                             this.body = HttpRequestBodyStream.fromByteArray(bodyBytes)

--- a/src/common/test/aws/sdk/kotlin/crt/io/UriTest.kt
+++ b/src/common/test/aws/sdk/kotlin/crt/io/UriTest.kt
@@ -109,6 +109,43 @@ class UriTest : CrtTest() {
     }
 
     @Test
+    fun authority() {
+        val tests = listOf(
+            "user:password@test.aws.com:1234" to UriBuilder.build {
+                userInfo = UserInfo("user", "password")
+                host = "test.aws.com"
+                port = 1234
+            },
+            "test.aws.com:1234" to UriBuilder.build {
+                host = "test.aws.com"
+                port = 1234
+            },
+            "user:password@test.aws.com" to UriBuilder.build {
+                userInfo = UserInfo("user", "password")
+                host = "test.aws.com"
+            },
+            "test.aws.com" to UriBuilder.build {
+                host = "test.aws.com"
+            },
+        )
+        tests.forEach { (expected, uri) -> assertEquals(expected, uri.authority) }
+    }
+
+    @Test
+    fun hostAndPort() {
+        val tests = listOf(
+            "test.aws.com:1234" to UriBuilder.build {
+                host = "test.aws.com"
+                port = 1234
+            },
+            "test.aws.com" to UriBuilder.build {
+                host = "test.aws.com"
+            },
+        )
+        tests.forEach { (expected, uri) -> assertEquals(expected, uri.hostAndPort) }
+    }
+
+    @Test
     fun itBuilds() {
         val builder = UriBuilder()
         builder.scheme = Protocol.HTTP


### PR DESCRIPTION
*Issue #, if available:*

Addresses awslabs/aws-sdk-kotlin#310

*Description of changes:*

Fixes scattered locations where URI ports are not respected (but hosts are). Also, adds convenience getters for URI properties **hostAndPort** and **authority**.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.