### PR TITLE
chore: bump aws-crt-java and coroutines to latest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ sdkVersion=0.5.3-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.6.10
-coroutinesVersion=1.5.2
+coroutinesVersion=1.6.0
 
 # testing/utility
 junitVersion=5.6.2
@@ -19,4 +19,4 @@ kotestVersion=4.6.2
 kotlinxCliVersion=0.3.2
 
 # JVM
-crtJavaVersion=0.15.6
+crtJavaVersion=0.15.18


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* bump `aws-crt-java` to latest which contains [fix](https://github.com/awslabs/aws-crt-java/commit/e21f806b39d5813a6095a4488369a63d6cedfbe3) for [aws-sdk-kotlin/511](https://github.com/awslabs/aws-sdk-kotlin/issues/511)
* bump kotlinx.coroutines to 1.6.0 to match `aws-sdk-kotlin` and `smithy-kotlin`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
