### PR TITLE
feat: upgrade kotlin 1.6.21; gradle 7.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ kotlin.mpp.stability.nowarn=true
 # kotlin.native.ignoreDisabledTargets=true
 
 # aws-crt-kotlin
-sdkVersion=0.5.5-SNAPSHOT
+sdkVersion=0.6.0-SNAPSHOT
 
 # kotlin
-kotlinVersion=1.6.10
-coroutinesVersion=1.6.0
+kotlinVersion=1.6.21
+coroutinesVersion=1.6.1
 
 # testing/utility
 junitVersion=5.6.2
@@ -19,4 +19,4 @@ kotestVersion=4.6.2
 kotlinxCliVersion=0.3.2
 
 # JVM
-crtJavaVersion=0.15.18
+crtJavaVersion=0.16.13

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Issue #, if available:*
related: https://github.com/awslabs/aws-sdk-kotlin/issues/473

*Description of changes:*
* Upgrade crt to 0.16.3 (which includes Mac M1 support)
* Upgrade kotlin to 1.6.21
* Upgrade gradle to 7.4.2

The last two should help build machine size/caches by aligning versions we use downstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
