### PR TITLE
chore: update/clarify changelog instructions in CONTRIBUTING.md

### DIFF
--- a/.changes/3c9cedab-7cd3-479c-b887-0cbdceeb9341.json
+++ b/.changes/3c9cedab-7cd3-479c-b887-0cbdceeb9341.json
@@ -1,0 +1,5 @@
+{
+    "id": "3c9cedab-7cd3-479c-b887-0cbdceeb9341",
+    "type": "misc",
+    "description": "Update/clarify changelog instructions in the Contributing Guidelines"
+}

--- a/.changes/3c9cedab-7cd3-479c-b887-0cbdceeb9341.json
+++ b/.changes/3c9cedab-7cd3-479c-b887-0cbdceeb9341.json
@@ -1,5 +1,5 @@
 {
     "id": "3c9cedab-7cd3-479c-b887-0cbdceeb9341",
     "type": "misc",
-    "description": "Update/clarify changelog instructions in the Contributing Guidelines"
+    "description": "Update/clarify changelog and add commit instructions in the Contributing Guidelines"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,10 @@ of your request may disagree and ask that you add one anyway.
 ### Git Commit Guidelines
 This project uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for its commit message format and expects all contributors to follow these guidelines.
 
-Each commit message consists of a **header**, a **body** (optional), and a **footer** (optional). The header has a special format that includes a **type**, a **scope** and a **subject**:
+Each commit message consists of a **header**, a **body** (optional), and a **footer** (optional). The header has a special format that includes a **type** and a **subject**:
 
 ```
-<type>(<scope>): <subject>
+<type>: <subject>
 <BLANK LINE>
 <body>
 <BLANK LINE>
@@ -104,13 +104,6 @@ Must be one of the following:
 - **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
 - **ci**: Changes to CI/CD scripts and tooling
 
-#### Scope
-
-The scope is optional but should be included when possible and refer to a module that is being touched. Examples:
-
-- codegen
-- rt (optionally the target platform e.g. rt-android)
-
 #### Subject
 
 The subject contains succinct description of the change:
@@ -121,7 +114,7 @@ The subject contains succinct description of the change:
 
 #### Body (optional)
 
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes". The body should include the motivation for the change and contrast this with previous behavior.
+Just as in the **subject**, use the imperative present tense (e.g., "change" not "changed" nor "changes"). The body should include the motivation for the change and contrast this with previous behavior.
 
 #### Footer (optional)
 
@@ -129,7 +122,7 @@ The footer should contain any information about **Breaking Changes** and is also
 
 The last line of commits introducing breaking changes should be in the form `BREAKING CHANGE: <desc>`
 
-Breaking changes should also add an exclamation mark `!` after the type/scope (e.g. `refactor(rt)!: drop support for Android API < 20`)
+Breaking changes should also add an exclamation mark `!` after the type (e.g. `refactor!: drop support for Android API < 20`)
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,13 @@ Merges to this repository must include one or more changelog entries which descr
 Entries are placed in the top-level `.changes/` directory. An entry is a file containing a JSON object with the
 following fields:
 
-| Field name    | Type       | Required | Enum                                         | Description                                                                                                                                                                                                                                                                                                                                     |
-|---------------|------------|----------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`          | `string`   | yes      |                                              | A unique identifier for this entry. We recommend you generate a UUID for this field.                                                                                                                                                                                                                                                            |
-| `type`        | `string`   | yes      | `bugfix`, `feature`, `documentation`, `misc` | The type of change being made.                                                                                                                                                                                                                                                                                                                  |
-| `description` | `string`   | yes      |                                              | A description of the change being made.                                                                                                                                                                                                                                                                                                         |
+| Field name    | Type       | Required | Enum                                         | Description                                                                                                                                                                                                                                                                                                                                      |
+|---------------|------------|----------|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`          | `string`   | yes      |                                              | A unique identifier for this entry. We recommend you generate a UUID for this field.                                                                                                                                                                                                                                                             |
+| `type`        | `string`   | yes      | `bugfix`, `feature`, `documentation`, `misc` | The type of change being made.                                                                                                                                                                                                                                                                                                                   |
+| `description` | `string`   | yes      |                                              | A description of the change being made.<ul><li>Prefix with `**Breaking**:` if the change is breaking</li><li>Use the imperative present tense (e.g., "change" not "changed" nor "changes")</li><li>Capitalize first letter</li><li>No dot (.) at the end unless there are multiple sentences</li></ul>                                           |
 | `issues`      | `string[]` | no       |                                              | A list of references to any related issues in the relevant repositories. A reference can be specified in several ways:<ul><li>The issue number, if local to this repository (eg. `#12345`)</li><li>A fully-qualified issue ID (eg.`awslabs/aws-sdk-kotlin#12345`)</li><li>A fully-qualified URL (eg. `https://issuetracker.com/12345`)</li></ul> |
-| `module`      | `string`   | no       |                                              | The area of the code affected by your changes. If unsure, leave this value unset.                                                                                                                                                                                                                                                               |
+| `module`      | `string`   | no       |                                              | The area of the code affected by your changes. If unsure, leave this value unset.                                                                                                                                                                                                                                                                |
 
 The filename of an entry is arbitrary. We recommend `<id>.json`, where `<id>` corresponds to the `id` field of the entry
 itself.
@@ -68,7 +68,7 @@ of your request may disagree and ask that you add one anyway.
 {
   "id": "263ea6ab-4b75-41a8-9c37-821c30d7b9e5",
   "type": "feature",
-  "description": "Add binding for CRT URL parsing.",
+  "description": "Add binding for CRT URL parsing",
   "issues": [
     "awslabs/aws-crt-kotlin#12345"
   ]
@@ -88,7 +88,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
 
 
 ## Licensing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,61 @@ of your request may disagree and ask that you add one anyway.
 }
 ```
 
+### Git Commit Guidelines
+This project uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for its commit message format and expects all contributors to follow these guidelines.
 
+Each commit message consists of a **header**, a **body** (optional), and a **footer** (optional). The header has a special format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+Any line of the commit message should not be longer 100 characters. This allows the message to be easier to read on GitHub as well as in various git tools.
+
+#### Type
+
+Must be one of the following:
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **refactor**: A code change that neither fixes a bug or adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests
+- **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+- **ci**: Changes to CI/CD scripts and tooling
+
+#### Scope
+
+The scope is optional but should be included when possible and refer to a module that is being touched. Examples:
+
+- codegen
+- rt (optionally the target platform e.g. rt-android)
+
+#### Subject
+
+The subject contains succinct description of the change:
+
+- Use the imperative present tense (e.g., "change" not "changed" nor "changes")
+- Don't capitalize first letter
+- No dot (.) at the end
+
+#### Body (optional)
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes". The body should include the motivation for the change and contrast this with previous behavior.
+
+#### Footer (optional)
+
+The footer should contain any information about **Breaking Changes** and is also the place to reference GitHub issues that this commit **Closes**.
+
+The last line of commits introducing breaking changes should be in the form `BREAKING CHANGE: <desc>`
+
+Breaking changes should also add an exclamation mark `!` after the type/scope (e.g. `refactor(rt)!: drop support for Android API < 20`)
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Update and clarify the contributing guidelines to more explicitly detail:

* Expected format for changelog entries

Similar to [smithy-kotlin#706](https://github.com/awslabs/smithy-kotlin/pull/706) except ~~without the commit guidelines because those don't exist in this guide~~ also add new commit guidelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.