### PR TITLE
fix: enable intra-repo links in API ref docs

### DIFF
--- a/.changes/d56dbe9f-1d82-4c2d-963d-23e4a406f381.json
+++ b/.changes/d56dbe9f-1d82-4c2d-963d-23e4a406f381.json
@@ -1,0 +1,8 @@
+{
+    "id": "d56dbe9f-1d82-4c2d-963d-23e4a406f381",
+    "type": "bugfix",
+    "description": "Enable intra-repo links in API ref docs",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#715"
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 kotlin.code.style=official
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
-# kotlin.native.ignoreDisabledTargets=true
-
-# FIXME - workaround for https://github.com/Kotlin/dokka/issues/2679
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 # aws-crt-kotlin

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
 # kotlin.native.ignoreDisabledTargets=true
 
+# FIXME - workaround for https://github.com/Kotlin/dokka/issues/2679
+kotlin.mpp.enableCompatibilityMetadataVariant=true
+
 # aws-crt-kotlin
 sdkVersion=0.6.5-SNAPSHOT
 


### PR DESCRIPTION
*Issue #, if available:* [aws-sdk-kotlin#715](https://github.com/awslabs/aws-sdk-kotlin/issues/715)

*Description of changes:*

Temporarily works around [dokka#2679](https://github.com/Kotlin/dokka/issues/2679) by enabling non-hierarchical project compatibility mode

**Companion PRs**: [smithy-kotlin#711](https://github.com/awslabs/smithy-kotlin/pull/711) & [aws-sdk-kotlin#716](https://github.com/awslabs/aws-sdk-kotlin/pull/716)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
