### PR TITLE
feat: add signing for chunk trailing headers

### DIFF
--- a/src/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigner.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigner.kt
@@ -5,6 +5,7 @@
 
 package aws.sdk.kotlin.crt.auth.signing
 
+import aws.sdk.kotlin.crt.http.Headers
 import aws.sdk.kotlin.crt.http.HttpRequest
 
 public expect object AwsSigner {
@@ -13,4 +14,6 @@ public expect object AwsSigner {
     public suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult
 
     public suspend fun signChunk(chunkBody: ByteArray, prevSignature: ByteArray, config: AwsSigningConfig): AwsSigningResult
+
+    public suspend fun signChunkTrailer(trailingHeaders: Headers, prevSignature: ByteArray, config: AwsSigningConfig): AwsSigningResult
 }

--- a/src/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig.kt
@@ -18,7 +18,8 @@ public enum class AwsSignatureType(public val value: Int) {
     HTTP_REQUEST_VIA_HEADERS(0),
     HTTP_REQUEST_VIA_QUERY_PARAMS(1),
     HTTP_REQUEST_CHUNK(2),
-    HTTP_REQUEST_EVENT(3);
+    HTTP_REQUEST_EVENT(3),
+    HTTP_REQUEST_TRAILING_HEADERS(6);
 }
 
 public object AwsSignedBodyValue {


### PR DESCRIPTION
*Issue #, if available:*
[awslabs/aws-sdk-kotlin/#747](https://github.com/awslabs/aws-sdk-kotlin/issues/747)

*Description of changes:*
Implements the CRT flavor of signChunkTrailer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.