### PR TITLE
feat: add `writeChunk` method to HttpStream

### DIFF
--- a/.changes/1695ebf6-1351-4555-8ab9-d90c91622549.json
+++ b/.changes/1695ebf6-1351-4555-8ab9-d90c91622549.json
@@ -1,0 +1,8 @@
+{
+    "id": "1695ebf6-1351-4555-8ab9-d90c91622549",
+    "type": "feature",
+    "description": "Add `writeChunk` method to HttpStream",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/759"
+    ]
+}

--- a/src/common/src/aws/sdk/kotlin/crt/http/HttpStream.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/http/HttpStream.kt
@@ -40,4 +40,11 @@ public interface HttpStream : Closeable {
      * Activate the client stream and start processing the request
      */
     public fun activate()
+
+    /**
+     * Send a chunk of data. You must call activate() before using this function.
+     * @param chunkData the chunk of data to send. this should be already formatted in the chunked transfer encoding.
+     * @param isFinalChunk represents if the chunk of data is the final chunk. if set to true, this will terminate the request stream.
+     */
+    public fun writeChunk(chunkData: ByteArray, isFinalChunk: Boolean)
 }

--- a/src/jvm/src/aws/sdk/kotlin/crt/http/HttpStreamJVM.kt
+++ b/src/jvm/src/aws/sdk/kotlin/crt/http/HttpStreamJVM.kt
@@ -19,4 +19,8 @@ internal class HttpStreamJVM(private val jniStream: HttpStreamJni) : HttpStream 
     override fun activate() = jniStream.activate()
 
     override fun close() = jniStream.close()
+
+    override fun writeChunk(chunkData: ByteArray, isFinalChunk: Boolean) {
+        jniStream.writeChunk(chunkData, isFinalChunk)
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/smithy-kotlin/issues/759

*Description of changes:*
This PR adds a `writeChunk` method to HttpStream. This wraps [Java CRT's writeChunk method](https://github.com/awslabs/aws-crt-java/blob/main/src/main/java/software/amazon/awssdk/crt/http/HttpStream.java#L71), which is used to make chunked transfer-encoding requests using CRT's HTTP engine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.