### PR TITLE
feat: add additional fields for connection tracing

### DIFF
--- a/src/common/src/aws/sdk/kotlin/crt/http/HttpClientConnection.kt
+++ b/src/common/src/aws/sdk/kotlin/crt/http/HttpClientConnection.kt
@@ -10,11 +10,15 @@ import aws.sdk.kotlin.crt.Closeable
 /**
  * This class wraps aws-c-http to provide the basic HTTP request/response functionality via the AWS Common Runtime.
  *
- * HttpClientConnection represents a single connection to a HTTP service endpoint.
+ * HttpClientConnection represents a single connection to an HTTP service endpoint.
  *
  * This class is not thread safe and should not be called from different threads.
  */
 public interface HttpClientConnection : Closeable {
+    /**
+     * The unique ID of this connection.
+     */
+    public val id: String
 
     /**
      * Schedules an HttpRequest on the Native EventLoop for this HttpClientConnection.

--- a/src/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionJVM.kt
+++ b/src/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionJVM.kt
@@ -11,6 +11,7 @@ import software.amazon.awssdk.crt.http.HttpClientConnection as HttpClientConnect
  * Wrapper around JNI HttpClientConnection type that implements the expected KMP interface
  */
 internal class HttpClientConnectionJVM constructor(internal val jniConn: HttpClientConnectionJni) : HttpClientConnection {
+    override val id: String = jniConn.nativeHandle.toString()
 
     override fun makeRequest(httpReq: HttpRequest, handler: HttpStreamResponseHandler): HttpStream {
         val jniStream = jniConn.makeRequest(httpReq.into(), handler.asJniStreamResponseHandler())


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Adds an additional `id` field to the HTTP connection interface to improve traceability.

**Companion PR**: [smithy-kotlin#796](https://github.com/awslabs/smithy-kotlin/pull/796)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
