### PR TITLE
feat: add binary-compatibility-validator plugin

### DIFF
--- a/api/android/aws-crt-kotlin.api
+++ b/api/android/aws-crt-kotlin.api
@@ -1,0 +1,939 @@
+public abstract interface class aws/sdk/kotlin/crt/AsyncShutdown {
+	public abstract fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/CRT {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/CRT;
+	public final fun errorName (I)Ljava/lang/String;
+	public final fun errorString (I)Ljava/lang/String;
+	public final fun initRuntime (Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun initRuntime$default (Laws/sdk/kotlin/crt/CRT;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun lastError ()I
+	public final fun nativeMemory ()J
+}
+
+public abstract interface class aws/sdk/kotlin/crt/Closeable {
+	public abstract fun close ()V
+}
+
+public final class aws/sdk/kotlin/crt/CloseableKt {
+	public static final fun use (Laws/sdk/kotlin/crt/Closeable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/Config {
+	public fun <init> ()V
+	public final fun getLogDestination ()Laws/sdk/kotlin/crt/LogDestination;
+	public final fun getLogFile ()Ljava/lang/String;
+	public final fun getLogLovel ()Laws/sdk/kotlin/crt/LogLevel;
+	public final fun setLogDestination (Laws/sdk/kotlin/crt/LogDestination;)V
+	public final fun setLogFile (Ljava/lang/String;)V
+	public final fun setLogLovel (Laws/sdk/kotlin/crt/LogLevel;)V
+}
+
+public class aws/sdk/kotlin/crt/CrtRuntimeException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getErrorCode ()I
+	public final fun getErrorDescription ()Ljava/lang/String;
+	public final fun getErrorName ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/LogDestination : java/lang/Enum {
+	public static final field File Laws/sdk/kotlin/crt/LogDestination;
+	public static final field None Laws/sdk/kotlin/crt/LogDestination;
+	public static final field Stderr Laws/sdk/kotlin/crt/LogDestination;
+	public static final field Stdout Laws/sdk/kotlin/crt/LogDestination;
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/LogDestination;
+	public static fun values ()[Laws/sdk/kotlin/crt/LogDestination;
+}
+
+public final class aws/sdk/kotlin/crt/LogLevel : java/lang/Enum {
+	public static final field Debug Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Error Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Fatal Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Info Laws/sdk/kotlin/crt/LogLevel;
+	public static final field None Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Trace Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Warn Laws/sdk/kotlin/crt/LogLevel;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/LogLevel;
+	public static fun values ()[Laws/sdk/kotlin/crt/LogLevel;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider;
+	public final fun getRefreshTimeInMilliseconds ()J
+	public final fun getSource ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun setRefreshTimeInMilliseconds (J)V
+	public final fun setSource (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/Credentials {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([B[B[B)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/auth/credentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessKeyId ()Ljava/lang/String;
+	public final fun getSecretAccessKey ()Ljava/lang/String;
+	public final fun getSessionToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public abstract fun getCredentials (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider;
+	public final fun getAuthToken ()Ljava/lang/String;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPathAndQuery ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setAuthToken (Ljava/lang/String;)V
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setHost (Ljava/lang/String;)V
+	public final fun setPathAndQuery (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider;
+}
+
+public abstract class aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider, java/io/Closeable {
+	public fun <init> ()V
+	public fun close ()V
+	public fun getCredentials (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getConfigFileName ()Ljava/lang/String;
+	public final fun getCredentialsFileName ()Ljava/lang/String;
+	public final fun getProfileName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setConfigFileName (Ljava/lang/String;)V
+	public final fun setCredentialsFileName (Ljava/lang/String;)V
+	public final fun setProfileName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;
+	public synthetic fun getJniCredentials$aws_crt_kotlin ()Lsoftware/amazon/awssdk/crt/auth/credentials/CredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+	public final fun getAccessKeyId ()Ljava/lang/String;
+	public final fun getSecretAccessKey ()Ljava/lang/String;
+	public final fun getSessionToken ()Ljava/lang/String;
+	public final fun setAccessKeyId (Ljava/lang/String;)V
+	public final fun setSecretAccessKey (Ljava/lang/String;)V
+	public final fun setSessionToken (Ljava/lang/String;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+	public static final fun fromCredentials (Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;Laws/sdk/kotlin/crt/auth/credentials/Credentials;)Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDurationSeconds ()Ljava/lang/Integer;
+	public final fun getRoleArn ()Ljava/lang/String;
+	public final fun getSessionName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setCredentialsProvider (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+	public final fun setDurationSeconds (Ljava/lang/Integer;)V
+	public final fun setRoleArn (Ljava/lang/String;)V
+	public final fun setSessionName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getRoleAlias ()Ljava/lang/String;
+	public final fun getThingName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setEndpoint (Ljava/lang/String;)V
+	public final fun setProxyOptions (Laws/sdk/kotlin/crt/http/HttpProxyOptions;)V
+	public final fun setRoleAlias (Ljava/lang/String;)V
+	public final fun setThingName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignatureType : java/lang/Enum {
+	public static final field HTTP_REQUEST_CHUNK Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_EVENT Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_TRAILING_HEADERS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_VIA_HEADERS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_VIA_QUERY_PARAMS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType : java/lang/Enum {
+	public static final field NONE Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public static final field X_AMZ_CONTENT_SHA256 Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignedBodyValue {
+	public static final field EMPTY_SHA256 Ljava/lang/String;
+	public static final field INSTANCE Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyValue;
+	public static final field STREAMING_AWS4_HMAC_SHA256_EVENTS Ljava/lang/String;
+	public static final field STREAMING_AWS4_HMAC_SHA256_PAYLOAD Ljava/lang/String;
+	public static final field UNSIGNED_PAYLOAD Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigner {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/auth/signing/AwsSigner;
+	public final fun sign (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signChunk ([B[BLaws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signChunkTrailer (Laws/sdk/kotlin/crt/http/Headers;[BLaws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signRequest (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm : java/lang/Enum {
+	public static final field SIGV4 Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static final field SIGV4_ASYMMETRIC Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Companion;
+	public fun <init> (Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder;)V
+	public final fun getAlgorithm ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getCredentials ()Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDate ()J
+	public final fun getExpirationInSeconds ()J
+	public final fun getNormalizeUriPath ()Z
+	public final fun getOmitSessionToken ()Z
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getShouldSignHeader ()Lkotlin/jvm/functions/Function1;
+	public final fun getSignatureType ()Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getSignedBodyValue ()Ljava/lang/String;
+	public final fun getUseDoubleUriEncode ()Z
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;
+	public final fun getAlgorithm ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getCredentials ()Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDate ()Ljava/lang/Long;
+	public final fun getExpirationInSeconds ()J
+	public final fun getNormalizeUriPath ()Z
+	public final fun getOmitSessionToken ()Z
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getShouldSignHeader ()Lkotlin/jvm/functions/Function1;
+	public final fun getSignatureType ()Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getSignedBodyValue ()Ljava/lang/String;
+	public final fun getUseDoubleUriEncode ()Z
+	public final fun setAlgorithm (Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;)V
+	public final fun setCredentials (Laws/sdk/kotlin/crt/auth/credentials/Credentials;)V
+	public final fun setCredentialsProvider (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+	public final fun setDate (Ljava/lang/Long;)V
+	public final fun setExpirationInSeconds (J)V
+	public final fun setNormalizeUriPath (Z)V
+	public final fun setOmitSessionToken (Z)V
+	public final fun setRegion (Ljava/lang/String;)V
+	public final fun setService (Ljava/lang/String;)V
+	public final fun setShouldSignHeader (Lkotlin/jvm/functions/Function1;)V
+	public final fun setSignatureType (Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;)V
+	public final fun setSignedBodyHeader (Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;)V
+	public final fun setSignedBodyValue (Ljava/lang/String;)V
+	public final fun setUseDoubleUriEncode (Z)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningResult {
+	public fun <init> (Laws/sdk/kotlin/crt/http/HttpRequest;[B)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public final fun component2 ()[B
+	public final fun copy (Laws/sdk/kotlin/crt/http/HttpRequest;[B)Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;Laws/sdk/kotlin/crt/http/HttpRequest;[BILjava/lang/Object;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSignature ()[B
+	public final fun getSignedRequest ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/Headers {
+	public static final field Companion Laws/sdk/kotlin/crt/http/Headers$Companion;
+	public abstract fun contains (Ljava/lang/String;)Z
+	public abstract fun contains (Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun entries ()Ljava/util/Set;
+	public abstract fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun isEmpty ()Z
+	public abstract fun names ()Ljava/util/Set;
+}
+
+public final class aws/sdk/kotlin/crt/http/Headers$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/Headers;
+}
+
+public final class aws/sdk/kotlin/crt/http/Headers$DefaultImpls {
+	public static fun contains (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;Ljava/lang/String;)Z
+	public static fun forEach (Laws/sdk/kotlin/crt/http/Headers;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HeadersBuilder {
+	public fun <init> ()V
+	public final fun append (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun appendAll (Laws/sdk/kotlin/crt/http/Headers;)V
+	public final fun appendAll (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public final fun appendMissing (Laws/sdk/kotlin/crt/http/Headers;)V
+	public final fun appendMissing (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public final fun build ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun clear ()V
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun contains (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun entries ()Ljava/util/Set;
+	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public final fun isEmpty ()Z
+	public final fun names ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;)Ljava/util/List;
+	public final fun remove (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun removeKeysWithNoEntries ()V
+	public final fun set (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpClientConnection : aws/sdk/kotlin/crt/Closeable {
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun makeRequest (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;)Laws/sdk/kotlin/crt/http/HttpStream;
+	public abstract fun shutdown ()V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManager : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;)V
+	public final fun acquireConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
+	public final fun getOptions ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+	public final fun releaseConnection (Laws/sdk/kotlin/crt/http/HttpClientConnection;)V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions$Companion;
+	public static final field DEFAULT_INITIAL_WINDOW_SIZE I
+	public static final field DEFAULT_MAX_CONNECTIONS I
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getInitialWindowSize ()I
+	public final fun getManualWindowManagement ()Z
+	public final fun getMaxConnectionIdleMs ()J
+	public final fun getMaxConnections ()I
+	public final fun getMonitoringOptions ()Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getSocketOptions ()Laws/sdk/kotlin/crt/io/SocketOptions;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun getUri ()Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptionsBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getInitialWindowSize ()I
+	public final fun getManualWindowManagement ()Z
+	public final fun getMaxConnectionIdleMs ()J
+	public final fun getMaxConnections ()I
+	public final fun getMonitoringOptions ()Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getSocketOptions ()Laws/sdk/kotlin/crt/io/SocketOptions;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun getUri ()Laws/sdk/kotlin/crt/io/Uri;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setInitialWindowSize (I)V
+	public final fun setManualWindowManagement (Z)V
+	public final fun setMaxConnectionIdleMs (J)V
+	public final fun setMaxConnections (I)V
+	public final fun setMonitoringOptions (Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;)V
+	public final fun setProxyOptions (Laws/sdk/kotlin/crt/http/HttpProxyOptions;)V
+	public final fun setSocketOptions (Laws/sdk/kotlin/crt/io/SocketOptions;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+	public final fun setUri (Laws/sdk/kotlin/crt/io/Uri;)V
+	public final fun uri (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpException : aws/sdk/kotlin/crt/CrtRuntimeException {
+	public fun <init> (I)V
+	public fun getErrorCode ()I
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpHeader {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeader;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpHeader;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpHeader;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpHeaderBlock : java/lang/Enum {
+	public static final field INFORMATIONAL Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static final field MAIN Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static final field TRAILING Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public final fun getBlockType ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpMonitoringOptions {
+	public fun <init> ()V
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;IIILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowableThroughputFailureIntervalSeconds ()I
+	public final fun getMinThroughputBytesPerSecond ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpProxyAuthorizationType : java/lang/Enum {
+	public static final field Basic Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public static final field None Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpProxyOptions {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun component6 ()Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;)Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpProxyOptions;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthPassword ()Ljava/lang/String;
+	public final fun getAuthType ()Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun getAuthUsername ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPort ()Ljava/lang/Integer;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequest {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun component4 ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)Laws/sdk/kotlin/crt/http/HttpRequest;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpRequest;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBody ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun getEncodedPath ()Ljava/lang/String;
+	public final fun getHeaders ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun getMethod ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequest$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/HttpRequest;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpRequestBodyStream {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpRequestBodyStream$Companion;
+	public abstract fun resetPosition ()Z
+	public abstract fun sendRequestBody (Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$Companion {
+	public final fun fromByteArray ([B)Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$DefaultImpls {
+	public static fun resetPosition (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)Z
+	public static fun sendRequestBody (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public final fun getBody ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun getEncodedPath ()Ljava/lang/String;
+	public final fun getHeaders ()Laws/sdk/kotlin/crt/http/HeadersBuilder;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun setBody (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)V
+	public final fun setEncodedPath (Ljava/lang/String;)V
+	public final fun setMethod (Ljava/lang/String;)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestKt {
+	public static final fun headers (Laws/sdk/kotlin/crt/http/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kotlin/crt/Closeable {
+	public abstract fun activate ()V
+	public abstract fun getResponseStatusCode ()I
+	public abstract fun incrementWindow (I)V
+	public abstract fun writeChunk ([BZ)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
+	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
+	public abstract fun onResponseComplete (Laws/sdk/kotlin/crt/http/HttpStream;I)V
+	public abstract fun onResponseHeaders (Laws/sdk/kotlin/crt/http/HttpStream;IILjava/util/List;)V
+	public abstract fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStream;I)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler$DefaultImpls {
+	public static fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
+	public static fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;I)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/io/Buffer {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Buffer$Companion;
+	public abstract fun copyTo ([BI)I
+	public abstract fun getLen ()I
+	public abstract fun readAll ()[B
+}
+
+public final class aws/sdk/kotlin/crt/io/Buffer$Companion {
+	public final fun getEmpty ()Laws/sdk/kotlin/crt/io/Buffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/Buffer$DefaultImpls {
+	public static synthetic fun copyTo$default (Laws/sdk/kotlin/crt/io/Buffer;[BIILjava/lang/Object;)I
+}
+
+public final class aws/sdk/kotlin/crt/io/BufferKt {
+	public static final fun byteArrayBuffer ([B)Laws/sdk/kotlin/crt/io/Buffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/ClientBootstrap : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;Laws/sdk/kotlin/crt/io/HostResolver;)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/EventLoopGroup : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/HostResolver : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;)V
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;I)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/MutableBuffer {
+	public static final field Companion Laws/sdk/kotlin/crt/io/MutableBuffer$Companion;
+	public fun <init> (Ljava/nio/ByteBuffer;)V
+	public final fun getBuffer ()Ljava/nio/ByteBuffer;
+	public final fun getWriteRemaining ()I
+	public final fun write ([BII)I
+	public static synthetic fun write$default (Laws/sdk/kotlin/crt/io/MutableBuffer;[BIIILjava/lang/Object;)I
+}
+
+public final class aws/sdk/kotlin/crt/io/MutableBuffer$Companion {
+	public final fun of ([B)Laws/sdk/kotlin/crt/io/MutableBuffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/Protocol {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Protocol$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Laws/sdk/kotlin/crt/io/Protocol;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;IILjava/lang/Object;)Laws/sdk/kotlin/crt/io/Protocol;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultPort ()I
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/Protocol$Companion {
+	public final fun createOrDefault (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getByName ()Ljava/util/Map;
+	public final fun getHTTP ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getHTTPS ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getWS ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getWSS ()Laws/sdk/kotlin/crt/io/Protocol;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketDomain : java/lang/Enum {
+	public static final field IPv4 Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static final field IPv6 Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static final field LOCAL Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/SocketDomain;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketOptions {
+	public fun <init> ()V
+	public fun <init> (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;III)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun component2 ()Laws/sdk/kotlin/crt/io/SocketType;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun copy (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;III)Laws/sdk/kotlin/crt/io/SocketOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/SocketOptions;Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;IIIILjava/lang/Object;)Laws/sdk/kotlin/crt/io/SocketOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnectTimeoutMs ()I
+	public final fun getDomain ()Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun getKeepAliveIntervalSecs ()I
+	public final fun getKeepAliveTimeoutSecs ()I
+	public final fun getType ()Laws/sdk/kotlin/crt/io/SocketType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketType : java/lang/Enum {
+	public static final field DGRAM Laws/sdk/kotlin/crt/io/SocketType;
+	public static final field STREAM Laws/sdk/kotlin/crt/io/SocketType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/SocketType;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/SocketType;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsCipherPreference : java/lang/Enum {
+	public static final field KMS_PQ_SIKE_TLS_V1_0_2019_11 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_SIKE_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2019_06 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2020_07 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field PQ_TLS_V1_0_2021_05 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field SYSTEM_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getValue ()I
+	public final fun isSupported ()Z
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContext : aws/sdk/kotlin/crt/Closeable {
+	public static final field Companion Laws/sdk/kotlin/crt/io/TlsContext$Companion;
+	public fun <init> ()V
+	public fun <init> (Laws/sdk/kotlin/crt/io/TlsContextOptions;)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/TlsContextOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContext$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextKt {
+	public static final fun build (Laws/sdk/kotlin/crt/io/TlsContext$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/TlsContext;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptions {
+	public static final field Companion Laws/sdk/kotlin/crt/io/TlsContextOptions$Companion;
+	public final fun getAlpn ()Ljava/lang/String;
+	public final fun getCaDir ()Ljava/lang/String;
+	public final fun getCaFile ()Ljava/lang/String;
+	public final fun getCaRoot ()Ljava/lang/String;
+	public final fun getCertificate ()Ljava/lang/String;
+	public final fun getCertificatePath ()Ljava/lang/String;
+	public final fun getMinTlsVersion ()Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getPkcs12Password ()Ljava/lang/String;
+	public final fun getPkcs12Path ()Ljava/lang/String;
+	public final fun getPrivateKey ()Ljava/lang/String;
+	public final fun getPrivateKeyPath ()Ljava/lang/String;
+	public final fun getTlsCipherPreference ()Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getVerifyPeer ()Z
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptions$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun defaultClient ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun defaultServer ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun isAlpnSupported ()Z
+	public final fun isCipherPreferenceSupported (Laws/sdk/kotlin/crt/io/TlsCipherPreference;)Z
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptionsBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun getAlpn ()Ljava/lang/String;
+	public final fun getCaDir ()Ljava/lang/String;
+	public final fun getCaFile ()Ljava/lang/String;
+	public final fun getCaRoot ()Ljava/lang/String;
+	public final fun getCertificate ()Ljava/lang/String;
+	public final fun getCertificatePath ()Ljava/lang/String;
+	public final fun getMinTlsVersion ()Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getPkcs12Password ()Ljava/lang/String;
+	public final fun getPkcs12Path ()Ljava/lang/String;
+	public final fun getPrivateKey ()Ljava/lang/String;
+	public final fun getPrivateKeyPath ()Ljava/lang/String;
+	public final fun getTlsCipherPreference ()Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getVerifyPeer ()Z
+	public final fun setAlpn (Ljava/lang/String;)V
+	public final fun setCaDir (Ljava/lang/String;)V
+	public final fun setCaFile (Ljava/lang/String;)V
+	public final fun setCaRoot (Ljava/lang/String;)V
+	public final fun setCertificate (Ljava/lang/String;)V
+	public final fun setCertificatePath (Ljava/lang/String;)V
+	public final fun setMinTlsVersion (Laws/sdk/kotlin/crt/io/TlsVersion;)V
+	public final fun setPkcs12Password (Ljava/lang/String;)V
+	public final fun setPkcs12Path (Ljava/lang/String;)V
+	public final fun setPrivateKey (Ljava/lang/String;)V
+	public final fun setPrivateKeyPath (Ljava/lang/String;)V
+	public final fun setTlsCipherPreference (Laws/sdk/kotlin/crt/io/TlsCipherPreference;)V
+	public final fun setVerifyPeer (Z)V
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsVersion : java/lang/Enum {
+	public static final field SSLv3 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field SYS_DEFAULT Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_1 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_2 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_3 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLSv1 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/TlsVersion;
+}
+
+public final class aws/sdk/kotlin/crt/io/Uri {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Uri$Companion;
+	public fun <init> (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;Z)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public final fun component8 ()Z
+	public final fun copy (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;Z)Laws/sdk/kotlin/crt/io/Uri;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/Uri;Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;ZILjava/lang/Object;)Laws/sdk/kotlin/crt/io/Uri;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Ljava/lang/String;
+	public final fun getForceQuery ()Z
+	public final fun getFragment ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getHostAndPort ()Ljava/lang/String;
+	public final fun getParameters ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPort ()I
+	public final fun getScheme ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getSpecifiedPort ()I
+	public final fun getUserInfo ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/Uri$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/Uri;
+	public final fun parse (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/io/UriBuilder {
+	public static final field Companion Laws/sdk/kotlin/crt/io/UriBuilder$Companion;
+	public fun <init> ()V
+	public final fun getForceQuery ()Z
+	public final fun getFragment ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getParameters ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPort ()Ljava/lang/Integer;
+	public final fun getScheme ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getUserInfo ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public final fun setForceQuery (Z)V
+	public final fun setFragment (Ljava/lang/String;)V
+	public final fun setHost (Ljava/lang/String;)V
+	public final fun setParameters (Ljava/lang/String;)V
+	public final fun setPath (Ljava/lang/String;)V
+	public final fun setPort (Ljava/lang/Integer;)V
+	public final fun setScheme (Laws/sdk/kotlin/crt/io/Protocol;)V
+	public final fun setUserInfo (Laws/sdk/kotlin/crt/io/UserInfo;)V
+}
+
+public final class aws/sdk/kotlin/crt/io/UriBuilder$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/io/UriKt {
+	public static final field DEFAULT_SCHEME_PORT I
+	public static final fun requiresTls (Laws/sdk/kotlin/crt/io/Protocol;)Z
+}
+
+public final class aws/sdk/kotlin/crt/io/UserInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/io/UserInfo;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/UserInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/io/UserInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/util/Digest {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/util/Digest;
+	public final fun sha256 ([B)[B
+}
+
+public final class aws/sdk/kotlin/crt/util/DigestKt {
+	public static final fun encodeToHex ([B)Ljava/lang/String;
+	public static final fun hex (Laws/sdk/kotlin/crt/util/Digest;[B)Ljava/lang/String;
+}
+

--- a/api/jvm/aws-crt-kotlin.api
+++ b/api/jvm/aws-crt-kotlin.api
@@ -1,0 +1,939 @@
+public abstract interface class aws/sdk/kotlin/crt/AsyncShutdown {
+	public abstract fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/CRT {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/CRT;
+	public final fun errorName (I)Ljava/lang/String;
+	public final fun errorString (I)Ljava/lang/String;
+	public final fun initRuntime (Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun initRuntime$default (Laws/sdk/kotlin/crt/CRT;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun lastError ()I
+	public final fun nativeMemory ()J
+}
+
+public abstract interface class aws/sdk/kotlin/crt/Closeable {
+	public abstract fun close ()V
+}
+
+public final class aws/sdk/kotlin/crt/CloseableKt {
+	public static final fun use (Laws/sdk/kotlin/crt/Closeable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/Config {
+	public fun <init> ()V
+	public final fun getLogDestination ()Laws/sdk/kotlin/crt/LogDestination;
+	public final fun getLogFile ()Ljava/lang/String;
+	public final fun getLogLovel ()Laws/sdk/kotlin/crt/LogLevel;
+	public final fun setLogDestination (Laws/sdk/kotlin/crt/LogDestination;)V
+	public final fun setLogFile (Ljava/lang/String;)V
+	public final fun setLogLovel (Laws/sdk/kotlin/crt/LogLevel;)V
+}
+
+public class aws/sdk/kotlin/crt/CrtRuntimeException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getErrorCode ()I
+	public final fun getErrorDescription ()Ljava/lang/String;
+	public final fun getErrorName ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/LogDestination : java/lang/Enum {
+	public static final field File Laws/sdk/kotlin/crt/LogDestination;
+	public static final field None Laws/sdk/kotlin/crt/LogDestination;
+	public static final field Stderr Laws/sdk/kotlin/crt/LogDestination;
+	public static final field Stdout Laws/sdk/kotlin/crt/LogDestination;
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/LogDestination;
+	public static fun values ()[Laws/sdk/kotlin/crt/LogDestination;
+}
+
+public final class aws/sdk/kotlin/crt/LogLevel : java/lang/Enum {
+	public static final field Debug Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Error Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Fatal Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Info Laws/sdk/kotlin/crt/LogLevel;
+	public static final field None Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Trace Laws/sdk/kotlin/crt/LogLevel;
+	public static final field Warn Laws/sdk/kotlin/crt/LogLevel;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/LogLevel;
+	public static fun values ()[Laws/sdk/kotlin/crt/LogLevel;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider;
+	public final fun getRefreshTimeInMilliseconds ()J
+	public final fun getSource ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun setRefreshTimeInMilliseconds (J)V
+	public final fun setSource (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/CachedCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/Credentials {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([B[B[B)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/auth/credentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessKeyId ()Ljava/lang/String;
+	public final fun getSecretAccessKey ()Ljava/lang/String;
+	public final fun getSessionToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public abstract fun getCredentials (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/DefaultChainCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider;
+	public final fun getAuthToken ()Ljava/lang/String;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPathAndQuery ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setAuthToken (Ljava/lang/String;)V
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setHost (Ljava/lang/String;)V
+	public final fun setPathAndQuery (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/EcsCredentialsProvider;
+}
+
+public abstract class aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider, java/io/Closeable {
+	public fun <init> ()V
+	public fun close ()V
+	public fun getCredentials (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getConfigFileName ()Ljava/lang/String;
+	public final fun getCredentialsFileName ()Ljava/lang/String;
+	public final fun getProfileName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setConfigFileName (Ljava/lang/String;)V
+	public final fun setCredentialsFileName (Ljava/lang/String;)V
+	public final fun setProfileName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/ProfileCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;
+	public synthetic fun getJniCredentials$aws_crt_kotlin ()Lsoftware/amazon/awssdk/crt/auth/credentials/CredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+	public final fun getAccessKeyId ()Ljava/lang/String;
+	public final fun getSecretAccessKey ()Ljava/lang/String;
+	public final fun getSessionToken ()Ljava/lang/String;
+	public final fun setAccessKeyId (Ljava/lang/String;)V
+	public final fun setSecretAccessKey (Ljava/lang/String;)V
+	public final fun setSessionToken (Ljava/lang/String;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+	public static final fun fromCredentials (Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider$Companion;Laws/sdk/kotlin/crt/auth/credentials/Credentials;)Laws/sdk/kotlin/crt/auth/credentials/StaticCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDurationSeconds ()Ljava/lang/Integer;
+	public final fun getRoleArn ()Ljava/lang/String;
+	public final fun getSessionName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setCredentialsProvider (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+	public final fun setDurationSeconds (Ljava/lang/Integer;)V
+	public final fun setRoleArn (Ljava/lang/String;)V
+	public final fun setSessionName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StsAssumeRoleCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/StsWebIdentityCredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider : aws/sdk/kotlin/crt/auth/credentials/JniCredentialsProvider, aws/sdk/kotlin/crt/auth/credentials/CredentialsProvider {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion;
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProviderBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getRoleAlias ()Ljava/lang/String;
+	public final fun getThingName ()Ljava/lang/String;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setEndpoint (Ljava/lang/String;)V
+	public final fun setProxyOptions (Laws/sdk/kotlin/crt/http/HttpProxyOptions;)V
+	public final fun setRoleAlias (Ljava/lang/String;)V
+	public final fun setThingName (Ljava/lang/String;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/credentials/X509CredentialsProviderKt {
+	public static final fun build (Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/credentials/X509CredentialsProvider;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignatureType : java/lang/Enum {
+	public static final field HTTP_REQUEST_CHUNK Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_EVENT Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_TRAILING_HEADERS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_VIA_HEADERS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static final field HTTP_REQUEST_VIA_QUERY_PARAMS Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType : java/lang/Enum {
+	public static final field NONE Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public static final field X_AMZ_CONTENT_SHA256 Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSignedBodyValue {
+	public static final field EMPTY_SHA256 Ljava/lang/String;
+	public static final field INSTANCE Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyValue;
+	public static final field STREAMING_AWS4_HMAC_SHA256_EVENTS Ljava/lang/String;
+	public static final field STREAMING_AWS4_HMAC_SHA256_PAYLOAD Ljava/lang/String;
+	public static final field UNSIGNED_PAYLOAD Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigner {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/auth/signing/AwsSigner;
+	public final fun sign (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signChunk ([B[BLaws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signChunkTrailer (Laws/sdk/kotlin/crt/http/Headers;[BLaws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun signRequest (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm : java/lang/Enum {
+	public static final field SIGV4 Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static final field SIGV4_ASYMMETRIC Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static fun values ()[Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig {
+	public static final field Companion Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Companion;
+	public fun <init> (Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder;)V
+	public final fun getAlgorithm ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getCredentials ()Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDate ()J
+	public final fun getExpirationInSeconds ()J
+	public final fun getNormalizeUriPath ()Z
+	public final fun getOmitSessionToken ()Z
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getShouldSignHeader ()Lkotlin/jvm/functions/Function1;
+	public final fun getSignatureType ()Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getSignedBodyValue ()Ljava/lang/String;
+	public final fun getUseDoubleUriEncode ()Z
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;
+	public final fun getAlgorithm ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public final fun getCredentials ()Laws/sdk/kotlin/crt/auth/credentials/Credentials;
+	public final fun getCredentialsProvider ()Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;
+	public final fun getDate ()Ljava/lang/Long;
+	public final fun getExpirationInSeconds ()J
+	public final fun getNormalizeUriPath ()Z
+	public final fun getOmitSessionToken ()Z
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getShouldSignHeader ()Lkotlin/jvm/functions/Function1;
+	public final fun getSignatureType ()Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;
+	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
+	public final fun getSignedBodyValue ()Ljava/lang/String;
+	public final fun getUseDoubleUriEncode ()Z
+	public final fun setAlgorithm (Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;)V
+	public final fun setCredentials (Laws/sdk/kotlin/crt/auth/credentials/Credentials;)V
+	public final fun setCredentialsProvider (Laws/sdk/kotlin/crt/auth/credentials/CredentialsProvider;)V
+	public final fun setDate (Ljava/lang/Long;)V
+	public final fun setExpirationInSeconds (J)V
+	public final fun setNormalizeUriPath (Z)V
+	public final fun setOmitSessionToken (Z)V
+	public final fun setRegion (Ljava/lang/String;)V
+	public final fun setService (Ljava/lang/String;)V
+	public final fun setShouldSignHeader (Lkotlin/jvm/functions/Function1;)V
+	public final fun setSignatureType (Laws/sdk/kotlin/crt/auth/signing/AwsSignatureType;)V
+	public final fun setSignedBodyHeader (Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;)V
+	public final fun setSignedBodyValue (Ljava/lang/String;)V
+	public final fun setUseDoubleUriEncode (Z)V
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig;
+}
+
+public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningResult {
+	public fun <init> (Laws/sdk/kotlin/crt/http/HttpRequest;[B)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public final fun component2 ()[B
+	public final fun copy (Laws/sdk/kotlin/crt/http/HttpRequest;[B)Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;Laws/sdk/kotlin/crt/http/HttpRequest;[BILjava/lang/Object;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSignature ()[B
+	public final fun getSignedRequest ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/Headers {
+	public static final field Companion Laws/sdk/kotlin/crt/http/Headers$Companion;
+	public abstract fun contains (Ljava/lang/String;)Z
+	public abstract fun contains (Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun entries ()Ljava/util/Set;
+	public abstract fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun isEmpty ()Z
+	public abstract fun names ()Ljava/util/Set;
+}
+
+public final class aws/sdk/kotlin/crt/http/Headers$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/Headers;
+}
+
+public final class aws/sdk/kotlin/crt/http/Headers$DefaultImpls {
+	public static fun contains (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;Ljava/lang/String;)Z
+	public static fun forEach (Laws/sdk/kotlin/crt/http/Headers;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HeadersBuilder {
+	public fun <init> ()V
+	public final fun append (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun appendAll (Laws/sdk/kotlin/crt/http/Headers;)V
+	public final fun appendAll (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public final fun appendMissing (Laws/sdk/kotlin/crt/http/Headers;)V
+	public final fun appendMissing (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public final fun build ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun clear ()V
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun contains (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun entries ()Ljava/util/Set;
+	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public final fun isEmpty ()Z
+	public final fun names ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;)Ljava/util/List;
+	public final fun remove (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun removeKeysWithNoEntries ()V
+	public final fun set (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpClientConnection : aws/sdk/kotlin/crt/Closeable {
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun makeRequest (Laws/sdk/kotlin/crt/http/HttpRequest;Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;)Laws/sdk/kotlin/crt/http/HttpStream;
+	public abstract fun shutdown ()V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManager : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;)V
+	public final fun acquireConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
+	public final fun getOptions ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+	public final fun releaseConnection (Laws/sdk/kotlin/crt/http/HttpClientConnection;)V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions$Companion;
+	public static final field DEFAULT_INITIAL_WINDOW_SIZE I
+	public static final field DEFAULT_MAX_CONNECTIONS I
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getInitialWindowSize ()I
+	public final fun getManualWindowManagement ()Z
+	public final fun getMaxConnectionIdleMs ()J
+	public final fun getMaxConnections ()I
+	public final fun getMonitoringOptions ()Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getSocketOptions ()Laws/sdk/kotlin/crt/io/SocketOptions;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun getUri ()Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptionsBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getInitialWindowSize ()I
+	public final fun getManualWindowManagement ()Z
+	public final fun getMaxConnectionIdleMs ()J
+	public final fun getMaxConnections ()I
+	public final fun getMonitoringOptions ()Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public final fun getProxyOptions ()Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public final fun getSocketOptions ()Laws/sdk/kotlin/crt/io/SocketOptions;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun getUri ()Laws/sdk/kotlin/crt/io/Uri;
+	public final fun setClientBootstrap (Laws/sdk/kotlin/crt/io/ClientBootstrap;)V
+	public final fun setInitialWindowSize (I)V
+	public final fun setManualWindowManagement (Z)V
+	public final fun setMaxConnectionIdleMs (J)V
+	public final fun setMaxConnections (I)V
+	public final fun setMonitoringOptions (Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;)V
+	public final fun setProxyOptions (Laws/sdk/kotlin/crt/http/HttpProxyOptions;)V
+	public final fun setSocketOptions (Laws/sdk/kotlin/crt/io/SocketOptions;)V
+	public final fun setTlsContext (Laws/sdk/kotlin/crt/io/TlsContext;)V
+	public final fun setUri (Laws/sdk/kotlin/crt/io/Uri;)V
+	public final fun uri (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpException : aws/sdk/kotlin/crt/CrtRuntimeException {
+	public fun <init> (I)V
+	public fun getErrorCode ()I
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpHeader {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeader;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpHeader;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpHeader;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpHeaderBlock : java/lang/Enum {
+	public static final field INFORMATIONAL Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static final field MAIN Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static final field TRAILING Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public final fun getBlockType ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpMonitoringOptions {
+	public fun <init> ()V
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;IIILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpMonitoringOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowableThroughputFailureIntervalSeconds ()I
+	public final fun getMinThroughputBytesPerSecond ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpProxyAuthorizationType : java/lang/Enum {
+	public static final field Basic Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public static final field None Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpProxyOptions {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public final fun component6 ()Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;)Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpProxyOptions;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/TlsContext;Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpProxyOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthPassword ()Ljava/lang/String;
+	public final fun getAuthType ()Laws/sdk/kotlin/crt/http/HttpProxyAuthorizationType;
+	public final fun getAuthUsername ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPort ()Ljava/lang/Integer;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequest {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpRequest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun component4 ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)Laws/sdk/kotlin/crt/http/HttpRequest;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpRequest;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/http/Headers;Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;ILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBody ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun getEncodedPath ()Ljava/lang/String;
+	public final fun getHeaders ()Laws/sdk/kotlin/crt/http/Headers;
+	public final fun getMethod ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequest$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/HttpRequest;
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpRequestBodyStream {
+	public static final field Companion Laws/sdk/kotlin/crt/http/HttpRequestBodyStream$Companion;
+	public abstract fun resetPosition ()Z
+	public abstract fun sendRequestBody (Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$Companion {
+	public final fun fromByteArray ([B)Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$DefaultImpls {
+	public static fun resetPosition (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)Z
+	public static fun sendRequestBody (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/http/HttpRequest;
+	public final fun getBody ()Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
+	public final fun getEncodedPath ()Ljava/lang/String;
+	public final fun getHeaders ()Laws/sdk/kotlin/crt/http/HeadersBuilder;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun setBody (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)V
+	public final fun setEncodedPath (Ljava/lang/String;)V
+	public final fun setMethod (Ljava/lang/String;)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpRequestKt {
+	public static final fun headers (Laws/sdk/kotlin/crt/http/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kotlin/crt/Closeable {
+	public abstract fun activate ()V
+	public abstract fun getResponseStatusCode ()I
+	public abstract fun incrementWindow (I)V
+	public abstract fun writeChunk ([BZ)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
+	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
+	public abstract fun onResponseComplete (Laws/sdk/kotlin/crt/http/HttpStream;I)V
+	public abstract fun onResponseHeaders (Laws/sdk/kotlin/crt/http/HttpStream;IILjava/util/List;)V
+	public abstract fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStream;I)V
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler$DefaultImpls {
+	public static fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
+	public static fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;I)V
+}
+
+public abstract interface class aws/sdk/kotlin/crt/io/Buffer {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Buffer$Companion;
+	public abstract fun copyTo ([BI)I
+	public abstract fun getLen ()I
+	public abstract fun readAll ()[B
+}
+
+public final class aws/sdk/kotlin/crt/io/Buffer$Companion {
+	public final fun getEmpty ()Laws/sdk/kotlin/crt/io/Buffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/Buffer$DefaultImpls {
+	public static synthetic fun copyTo$default (Laws/sdk/kotlin/crt/io/Buffer;[BIILjava/lang/Object;)I
+}
+
+public final class aws/sdk/kotlin/crt/io/BufferKt {
+	public static final fun byteArrayBuffer ([B)Laws/sdk/kotlin/crt/io/Buffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/ClientBootstrap : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;Laws/sdk/kotlin/crt/io/HostResolver;)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/EventLoopGroup : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/HostResolver : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;)V
+	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;I)V
+	public fun close ()V
+	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/sdk/kotlin/crt/io/MutableBuffer {
+	public static final field Companion Laws/sdk/kotlin/crt/io/MutableBuffer$Companion;
+	public fun <init> (Ljava/nio/ByteBuffer;)V
+	public final fun getBuffer ()Ljava/nio/ByteBuffer;
+	public final fun getWriteRemaining ()I
+	public final fun write ([BII)I
+	public static synthetic fun write$default (Laws/sdk/kotlin/crt/io/MutableBuffer;[BIIILjava/lang/Object;)I
+}
+
+public final class aws/sdk/kotlin/crt/io/MutableBuffer$Companion {
+	public final fun of ([B)Laws/sdk/kotlin/crt/io/MutableBuffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/Protocol {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Protocol$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Laws/sdk/kotlin/crt/io/Protocol;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;IILjava/lang/Object;)Laws/sdk/kotlin/crt/io/Protocol;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultPort ()I
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/Protocol$Companion {
+	public final fun createOrDefault (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getByName ()Ljava/util/Map;
+	public final fun getHTTP ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getHTTPS ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getWS ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getWSS ()Laws/sdk/kotlin/crt/io/Protocol;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketDomain : java/lang/Enum {
+	public static final field IPv4 Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static final field IPv6 Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static final field LOCAL Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/SocketDomain;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/SocketDomain;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketOptions {
+	public fun <init> ()V
+	public fun <init> (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;III)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun component2 ()Laws/sdk/kotlin/crt/io/SocketType;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun copy (Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;III)Laws/sdk/kotlin/crt/io/SocketOptions;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/SocketOptions;Laws/sdk/kotlin/crt/io/SocketDomain;Laws/sdk/kotlin/crt/io/SocketType;IIIILjava/lang/Object;)Laws/sdk/kotlin/crt/io/SocketOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnectTimeoutMs ()I
+	public final fun getDomain ()Laws/sdk/kotlin/crt/io/SocketDomain;
+	public final fun getKeepAliveIntervalSecs ()I
+	public final fun getKeepAliveTimeoutSecs ()I
+	public final fun getType ()Laws/sdk/kotlin/crt/io/SocketType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/SocketType : java/lang/Enum {
+	public static final field DGRAM Laws/sdk/kotlin/crt/io/SocketType;
+	public static final field STREAM Laws/sdk/kotlin/crt/io/SocketType;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/SocketType;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/SocketType;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsCipherPreference : java/lang/Enum {
+	public static final field KMS_PQ_SIKE_TLS_V1_0_2019_11 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_SIKE_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2019_06 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field KMS_PQ_TLS_V1_0_2020_07 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field PQ_TLS_V1_0_2021_05 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field SYSTEM_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getValue ()I
+	public final fun isSupported ()Z
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContext : aws/sdk/kotlin/crt/Closeable {
+	public static final field Companion Laws/sdk/kotlin/crt/io/TlsContext$Companion;
+	public fun <init> ()V
+	public fun <init> (Laws/sdk/kotlin/crt/io/TlsContextOptions;)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/TlsContextOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContext$Companion {
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextKt {
+	public static final fun build (Laws/sdk/kotlin/crt/io/TlsContext$Companion;Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/TlsContext;
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptions {
+	public static final field Companion Laws/sdk/kotlin/crt/io/TlsContextOptions$Companion;
+	public final fun getAlpn ()Ljava/lang/String;
+	public final fun getCaDir ()Ljava/lang/String;
+	public final fun getCaFile ()Ljava/lang/String;
+	public final fun getCaRoot ()Ljava/lang/String;
+	public final fun getCertificate ()Ljava/lang/String;
+	public final fun getCertificatePath ()Ljava/lang/String;
+	public final fun getMinTlsVersion ()Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getPkcs12Password ()Ljava/lang/String;
+	public final fun getPkcs12Path ()Ljava/lang/String;
+	public final fun getPrivateKey ()Ljava/lang/String;
+	public final fun getPrivateKeyPath ()Ljava/lang/String;
+	public final fun getTlsCipherPreference ()Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getVerifyPeer ()Z
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptions$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun defaultClient ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun defaultServer ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun isAlpnSupported ()Z
+	public final fun isCipherPreferenceSupported (Laws/sdk/kotlin/crt/io/TlsCipherPreference;)Z
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsContextOptionsBuilder {
+	public fun <init> ()V
+	public final fun build ()Laws/sdk/kotlin/crt/io/TlsContextOptions;
+	public final fun getAlpn ()Ljava/lang/String;
+	public final fun getCaDir ()Ljava/lang/String;
+	public final fun getCaFile ()Ljava/lang/String;
+	public final fun getCaRoot ()Ljava/lang/String;
+	public final fun getCertificate ()Ljava/lang/String;
+	public final fun getCertificatePath ()Ljava/lang/String;
+	public final fun getMinTlsVersion ()Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getPkcs12Password ()Ljava/lang/String;
+	public final fun getPkcs12Path ()Ljava/lang/String;
+	public final fun getPrivateKey ()Ljava/lang/String;
+	public final fun getPrivateKeyPath ()Ljava/lang/String;
+	public final fun getTlsCipherPreference ()Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public final fun getVerifyPeer ()Z
+	public final fun setAlpn (Ljava/lang/String;)V
+	public final fun setCaDir (Ljava/lang/String;)V
+	public final fun setCaFile (Ljava/lang/String;)V
+	public final fun setCaRoot (Ljava/lang/String;)V
+	public final fun setCertificate (Ljava/lang/String;)V
+	public final fun setCertificatePath (Ljava/lang/String;)V
+	public final fun setMinTlsVersion (Laws/sdk/kotlin/crt/io/TlsVersion;)V
+	public final fun setPkcs12Password (Ljava/lang/String;)V
+	public final fun setPkcs12Path (Ljava/lang/String;)V
+	public final fun setPrivateKey (Ljava/lang/String;)V
+	public final fun setPrivateKeyPath (Ljava/lang/String;)V
+	public final fun setTlsCipherPreference (Laws/sdk/kotlin/crt/io/TlsCipherPreference;)V
+	public final fun setVerifyPeer (Z)V
+}
+
+public final class aws/sdk/kotlin/crt/io/TlsVersion : java/lang/Enum {
+	public static final field SSLv3 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field SYS_DEFAULT Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_1 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_2 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLS_V1_3 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static final field TLSv1 Laws/sdk/kotlin/crt/io/TlsVersion;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/TlsVersion;
+	public static fun values ()[Laws/sdk/kotlin/crt/io/TlsVersion;
+}
+
+public final class aws/sdk/kotlin/crt/io/Uri {
+	public static final field Companion Laws/sdk/kotlin/crt/io/Uri$Companion;
+	public fun <init> (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;Z)V
+	public synthetic fun <init> (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public final fun component8 ()Z
+	public final fun copy (Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;Z)Laws/sdk/kotlin/crt/io/Uri;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/Uri;Laws/sdk/kotlin/crt/io/Protocol;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/sdk/kotlin/crt/io/UserInfo;ZILjava/lang/Object;)Laws/sdk/kotlin/crt/io/Uri;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Ljava/lang/String;
+	public final fun getForceQuery ()Z
+	public final fun getFragment ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getHostAndPort ()Ljava/lang/String;
+	public final fun getParameters ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPort ()I
+	public final fun getScheme ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getSpecifiedPort ()I
+	public final fun getUserInfo ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/io/Uri$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/Uri;
+	public final fun parse (Ljava/lang/String;)Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/io/UriBuilder {
+	public static final field Companion Laws/sdk/kotlin/crt/io/UriBuilder$Companion;
+	public fun <init> ()V
+	public final fun getForceQuery ()Z
+	public final fun getFragment ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getParameters ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPort ()Ljava/lang/Integer;
+	public final fun getScheme ()Laws/sdk/kotlin/crt/io/Protocol;
+	public final fun getUserInfo ()Laws/sdk/kotlin/crt/io/UserInfo;
+	public final fun setForceQuery (Z)V
+	public final fun setFragment (Ljava/lang/String;)V
+	public final fun setHost (Ljava/lang/String;)V
+	public final fun setParameters (Ljava/lang/String;)V
+	public final fun setPath (Ljava/lang/String;)V
+	public final fun setPort (Ljava/lang/Integer;)V
+	public final fun setScheme (Laws/sdk/kotlin/crt/io/Protocol;)V
+	public final fun setUserInfo (Laws/sdk/kotlin/crt/io/UserInfo;)V
+}
+
+public final class aws/sdk/kotlin/crt/io/UriBuilder$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/io/Uri;
+}
+
+public final class aws/sdk/kotlin/crt/io/UriKt {
+	public static final field DEFAULT_SCHEME_PORT I
+	public static final fun requiresTls (Laws/sdk/kotlin/crt/io/Protocol;)Z
+}
+
+public final class aws/sdk/kotlin/crt/io/UserInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/sdk/kotlin/crt/io/UserInfo;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/io/UserInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/sdk/kotlin/crt/io/UserInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassword ()Ljava/lang/String;
+	public final fun getUsername ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/util/Digest {
+	public static final field INSTANCE Laws/sdk/kotlin/crt/util/Digest;
+	public final fun sha256 ([B)[B
+}
+
+public final class aws/sdk/kotlin/crt/util/DigestKt {
+	public static final fun encodeToHex ([B)Ljava/lang/String;
+	public static final fun hex (Laws/sdk/kotlin/crt/util/Digest;[B)Ljava/lang/String;
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ import java.util.Properties
 plugins {
     kotlin("multiplatform")
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.1"
 }
 
 val sdkVersion: String by project
@@ -226,3 +227,7 @@ tasks.register<JavaExec>("ktlintFormat") {
 }
 
 tasks.check.get().dependsOn(":ktlint")
+
+apiValidation {
+    ignoredProjects += setOf("elasticurl")
+}

--- a/builder.json
+++ b/builder.json
@@ -18,6 +18,7 @@
         "{gradlew} publishToMavenLocal"
     ],
     "test_steps": [
+        "{gradlew} apiCheck",
         "{gradlew} test allTests"
     ],
     "targets": {
@@ -29,6 +30,7 @@
                 "{gradlew} assemble -Dlibcrypto.path={libcrypto_path}"
             ],
             "!test_steps": [
+                "{gradlew} apiCheck",
                 "{gradlew} test allTests -Dlibcrypto.path={libcrypto_path}"
             ]
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 kotlin.code.style=official
-kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This adds the binary-compatibility-validator plugin which was previously added in [smithy-kotlin](https://github.com/awslabs/smithy-kotlin/pull/808) and [aws-sdk-kotlin](https://github.com/awslabs/aws-sdk-kotlin/pull/856).

Also this removes the `kotlin.mpp.enableGranularSourceSetsMetadata` property because it is now deprecated and prints a warning during builds: 
> The property 'kotlin.mpp.enableGranularSourceSetsMetadata=true' has no effect in this and future Kotlin versions, as Hierarchical Structures support is now enabled by default. It is safe to remove the property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
