### PR TITLE
fix: fix publishing properties

### DIFF
--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 val sdkVersion: String by project
-group = "aws.sdk.kotlin.crt"
+group = properties["publishGroupName"] ?: error("missing publishGroupName")
 version = sdkVersion
 description = "Kotlin Multiplatform bindings for AWS SDK Common Runtime"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ kotlinxCliVersion=0.3.2
 
 # JVM
 crtJavaVersion=0.26.1
+
+# publishing
+publishGroupName=aws.sdk.kotlin.crt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The migrated [publish logic](https://github.com/awslabs/aws-kotlin-repo-tools/blob/main/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt#L105) in the shared build plugin expects `publishGroupName` or else it disables the nexus publishing tasks. The release stacks for `aws-sdk-kotlin` and `smithy-kotlin` explicitly set this property, rather than update the stack I've just set it directly since we only have one publishing group. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
