### PR TITLE
chore: remove unused experimental annotations

### DIFF
--- a/elasticurl/src/commonMain/kotlin/Application.kt
+++ b/elasticurl/src/commonMain/kotlin/Application.kt
@@ -7,10 +7,8 @@ import aws.sdk.kotlin.crt.CrtRuntimeException
 import aws.sdk.kotlin.crt.LogDestination
 import aws.sdk.kotlin.crt.http.*
 import aws.sdk.kotlin.crt.io.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 
-@ExperimentalCoroutinesApi
 fun main(args: Array<String>) {
     platformInit()
 
@@ -115,7 +113,6 @@ fun main(args: Array<String>) {
     println("exiting")
 }
 
-@ExperimentalCoroutinesApi
 private suspend fun HttpClientConnection.roundTrip(request: HttpRequest, sink: Sink) {
     val streamDone = Channel<Unit>()
 


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/awslabs/aws-sdk-kotlin/issues/860

*Description of changes:*

This change removes some now-unnecessary opt-ins for experimental annotations. No functional change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
