### PR TITLE
misc: bump allocated heap and metaspace memory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
         // only need to include it here, imports in subprojects will work automagically
         classpath("aws.sdk.kotlin:build-plugins") {
             version {
-                require("0.2.5")
+                require("0.2.6")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ crtJavaVersion=0.27.4
 
 # publishing
 publishGroupName=aws.sdk.kotlin.crt
+
+# gradle
+org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumps the heap memory to 2G and metaspace memory to 1G to resolve OOM errors during builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
