### PR TITLE
feat: add support for determining HTTP exception retryability

### DIFF
--- a/aws-crt-kotlin/api/android/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/android/aws-crt-kotlin.api
@@ -8,6 +8,7 @@ public final class aws/sdk/kotlin/crt/CRT {
 	public final fun errorString (I)Ljava/lang/String;
 	public final fun initRuntime (Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun initRuntime$default (Laws/sdk/kotlin/crt/CRT;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun isHttpErrorRetryable (I)Z
 	public final fun lastError ()I
 	public final fun nativeMemory ()J
 }

--- a/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
@@ -8,6 +8,7 @@ public final class aws/sdk/kotlin/crt/CRT {
 	public final fun errorString (I)Ljava/lang/String;
 	public final fun initRuntime (Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun initRuntime$default (Laws/sdk/kotlin/crt/CRT;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun isHttpErrorRetryable (I)Z
 	public final fun lastError ()I
 	public final fun nativeMemory ()J
 }

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/CRT.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/CRT.kt
@@ -18,20 +18,27 @@ public expect object CRT {
     public fun lastError(): Int
 
     /**
-     * Given an integer error code from an internal operation
+     * Given an integer error code from an internal operation, return the associated error message.
      * @param errorCode An error code returned from an exception or other native function call
      * @return A user-friendly description of the error
      */
     public fun errorString(errorCode: Int): String?
 
     /**
-     * Given an integer error code from an internal operation
+     * Given an integer error code from an internal operation, return the associated error name.
      *
      * @param errorCode An error code returned from an exception or other native
      * function call
      * @return A string identifier for the error
      */
     public fun errorName(errorCode: Int): String?
+
+    /**
+     * Given an integer HTTP error code from an internal operation, return whether the error is retryable.
+     * @param errorCode An error code returned from an exception or other native function call
+     * @return True if the given HTTP error is retryable; otherwise, false.
+     */
+    public fun isHttpErrorRetryable(errorCode: Int): Boolean
 
     /**
      * @return The number of bytes allocated in native resources. If aws.crt.memory.tracing is 1 or 2, this will

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/CRTNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/CRTNative.kt
@@ -34,6 +34,10 @@ public actual object CRT {
         TODO("Not yet implemented")
     }
 
+    public actual fun isHttpErrorRetryable(errorCode: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
     /**
      * @return The number of bytes allocated in native resources. If aws.crt.memory.tracing is 1 or 2, this will
      * be a non-zero value. Otherwise, no tracing will be done, and the value will always be 0


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:*

Adds a binding for determining if a CRT HTTP exception is retryable according to the [logic already coded in **aws-crt-java**](https://github.com/awslabs/aws-crt-java/blob/1cb7add5fa641c62f8445c9690cba25c4e272aa5/src/native/http_request_response.c#L713-L740).

**Companion PR**: https://github.com/awslabs/smithy-kotlin/pull/990

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
