### PR TITLE
feat: enable access to metrics for HTTP streams

### DIFF
--- a/.changes/cfc58da7-d2c6-47d7-a40e-72893b49bca7.json
+++ b/.changes/cfc58da7-d2c6-47d7-a40e-72893b49bca7.json
@@ -1,0 +1,8 @@
+{
+    "id": "cfc58da7-d2c6-47d7-a40e-72893b49bca7",
+    "type": "feature",
+    "description": "Enable access to metrics for HTTP streams",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/893"
+    ]
+}

--- a/aws-crt-kotlin/api/android/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/android/aws-crt-kotlin.api
@@ -635,6 +635,7 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kot
 }
 
 public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
+	public abstract fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
 	public abstract fun onResponseComplete (Laws/sdk/kotlin/crt/http/HttpStream;I)V
 	public abstract fun onResponseHeaders (Laws/sdk/kotlin/crt/http/HttpStream;IILjava/util/List;)V
@@ -642,6 +643,7 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandle
 }
 
 public final class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler$DefaultImpls {
+	public static fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public static fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
 	public static fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;I)V
 }

--- a/aws-crt-kotlin/api/android/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/android/aws-crt-kotlin.api
@@ -634,6 +634,33 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kot
 	public abstract fun writeChunk ([BZ)V
 }
 
+public final class aws/sdk/kotlin/crt/http/HttpStreamMetrics {
+	public fun <init> (JJJJJJI)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()I
+	public final fun copy (JJJJJJI)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpStreamMetrics;JJJJJJIILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReceiveEndTimestampNs ()J
+	public final fun getReceiveStartTimestampNs ()J
+	public final fun getReceivingDurationNs ()J
+	public final fun getSendEndTimestampNs ()J
+	public final fun getSendStartTimestampNs ()J
+	public final fun getSendingDurationNs ()J
+	public final fun getStreamId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpStreamMetricsJVMKt {
+	public static final fun toKotlin (Lsoftware/amazon/awssdk/crt/http/HttpStreamMetrics;)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+}
+
 public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
 	public abstract fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I

--- a/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
@@ -635,6 +635,7 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kot
 }
 
 public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
+	public abstract fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
 	public abstract fun onResponseComplete (Laws/sdk/kotlin/crt/http/HttpStream;I)V
 	public abstract fun onResponseHeaders (Laws/sdk/kotlin/crt/http/HttpStream;IILjava/util/List;)V
@@ -642,6 +643,7 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandle
 }
 
 public final class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler$DefaultImpls {
+	public static fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public static fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
 	public static fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;I)V
 }

--- a/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
@@ -634,6 +634,33 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStream : aws/sdk/kot
 	public abstract fun writeChunk ([BZ)V
 }
 
+public final class aws/sdk/kotlin/crt/http/HttpStreamMetrics {
+	public fun <init> (JJJJJJI)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()I
+	public final fun copy (JJJJJJI)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpStreamMetrics;JJJJJJIILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReceiveEndTimestampNs ()J
+	public final fun getReceiveStartTimestampNs ()J
+	public final fun getReceivingDurationNs ()J
+	public final fun getSendEndTimestampNs ()J
+	public final fun getSendStartTimestampNs ()J
+	public final fun getSendingDurationNs ()J
+	public final fun getStreamId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpStreamMetricsJVMKt {
+	public static final fun toKotlin (Lsoftware/amazon/awssdk/crt/http/HttpStreamMetrics;)Laws/sdk/kotlin/crt/http/HttpStreamMetrics;
+}
+
 public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler {
 	public abstract fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
 	public abstract fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpStreamMetrics.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpStreamMetrics.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.crt.http
+
+public data class HttpStreamMetrics(
+    val sendStartTimestampNs: Long,
+    val sendEndTimestampNs: Long,
+    val sendingDurationNs: Long,
+    val receiveStartTimestampNs: Long,
+    val receiveEndTimestampNs: Long,
+    val receivingDurationNs: Long,
+    val streamId: Int,
+)

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpStreamResponseHandler.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpStreamResponseHandler.kt
@@ -69,6 +69,15 @@ public interface HttpStreamResponseHandler {
         bodyBytesIn.len
 
     /**
+     * Called right before stream is complete, whether successful or unsuccessful.
+     * @param stream The HTTP stream to which the metrics apply
+     * @param metrics The [HttpStreamMetrics] containing metrics for the given stream
+     */
+    public fun onMetrics(stream: HttpStream, metrics: HttpStreamMetrics) {
+        /* Optional callback, nothing to do by default */
+    }
+
+    /**
      * Called from Native when the Response has completed.
      * @param stream completed stream
      * @param errorCode resultant errorCode for the response

--- a/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/http/HttpStreamMetricsJVM.kt
+++ b/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/http/HttpStreamMetricsJVM.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.crt.http
+
+/**
+ * Convert a CRT JNI metrics object into a Kotlin-native one
+ */
+public fun software.amazon.awssdk.crt.http.HttpStreamMetrics.toKotlin(): HttpStreamMetrics =
+    HttpStreamMetrics(
+        sendStartTimestampNs = this.sendStartTimestampNs,
+        sendEndTimestampNs = this.sendEndTimestampNs,
+        sendingDurationNs = this.sendingDurationNs,
+        receiveStartTimestampNs = this.receiveStartTimestampNs,
+        receiveEndTimestampNs = this.receiveEndTimestampNs,
+        receivingDurationNs = this.receivingDurationNs,
+        streamId = this.streamId,
+    )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 buildscript {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 
     dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin-version = "1.9.21"
 
 # libs
-crt-java-version = "0.29.1"
+crt-java-version = "0.29.6"
 coroutines-version = "1.7.3"
 
 # testing


### PR DESCRIPTION
**Issue #, if available**: https://github.com/awslabs/smithy-kotlin/issues/893

**Description of changes**: This change consumes upstream changes in https://github.com/awslabs/aws-crt-java/pull/738 which provide a new callback for receiving metrics from HTTP streams

**Companion PRs**: https://github.com/awslabs/aws-crt-java/pull/738, https://github.com/awslabs/smithy-kotlin/pull/1017

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
