### PR TITLE
feat: surface HTTP connection manager metrics

### DIFF
--- a/.changes/11a891eb-b51f-4508-9010-f17d35ce96a3.json
+++ b/.changes/11a891eb-b51f-4508-9010-f17d35ce96a3.json
@@ -1,0 +1,8 @@
+{
+    "id": "11a891eb-b51f-4508-9010-f17d35ce96a3",
+    "type": "feature",
+    "description": "Surface HTTP connection manager metrics",
+    "issues": [
+        "awslabs/smithy-kotlin#893"
+    ]
+}

--- a/aws-crt-kotlin/api/android/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/android/aws-crt-kotlin.api
@@ -448,6 +448,7 @@ public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManager : aws/sdk
 	public fun <init> (Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;)V
 	public final fun acquireConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
+	public final fun getManagerMetrics ()Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
 	public final fun getOptions ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
 	public final fun releaseConnection (Laws/sdk/kotlin/crt/http/HttpClientConnection;)V
 	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -525,6 +526,21 @@ public final class aws/sdk/kotlin/crt/http/HttpHeaderBlock : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
 	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpManagerMetrics {
+	public fun <init> (JJJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun copy (JJJ)Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpManagerMetrics;JJJILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailableConcurrency ()J
+	public final fun getLeasedConcurrency ()J
+	public final fun getPendingConcurrencyAcquires ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/sdk/kotlin/crt/http/HttpMonitoringOptions {

--- a/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
@@ -448,6 +448,7 @@ public final class aws/sdk/kotlin/crt/http/HttpClientConnectionManager : aws/sdk
 	public fun <init> (Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;)V
 	public final fun acquireConnection (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
+	public final fun getManagerMetrics ()Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
 	public final fun getOptions ()Laws/sdk/kotlin/crt/http/HttpClientConnectionManagerOptions;
 	public final fun releaseConnection (Laws/sdk/kotlin/crt/http/HttpClientConnection;)V
 	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -525,6 +526,21 @@ public final class aws/sdk/kotlin/crt/http/HttpHeaderBlock : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
 	public static fun values ()[Laws/sdk/kotlin/crt/http/HttpHeaderBlock;
+}
+
+public final class aws/sdk/kotlin/crt/http/HttpManagerMetrics {
+	public fun <init> (JJJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun copy (JJJ)Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
+	public static synthetic fun copy$default (Laws/sdk/kotlin/crt/http/HttpManagerMetrics;JJJILjava/lang/Object;)Laws/sdk/kotlin/crt/http/HttpManagerMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailableConcurrency ()J
+	public final fun getLeasedConcurrency ()J
+	public final fun getPendingConcurrencyAcquires ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/sdk/kotlin/crt/http/HttpMonitoringOptions {

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManager.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManager.kt
@@ -15,6 +15,11 @@ public expect class HttpClientConnectionManager(options: HttpClientConnectionMan
     Closeable,
     AsyncShutdown {
     /**
+     * The active metrics for this connection manager
+     */
+    public val managerMetrics: HttpManagerMetrics
+
+    /**
      * The options this manager was configured with
      */
     public val options: HttpClientConnectionManagerOptions

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpManagerMetrics.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/http/HttpManagerMetrics.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.crt.http
+
+public data class HttpManagerMetrics(
+    public val availableConcurrency: Long,
+    public val pendingConcurrencyAcquires: Long,
+    public val leasedConcurrency: Long,
+)

--- a/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManagerJVM.kt
+++ b/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManagerJVM.kt
@@ -24,6 +24,16 @@ public actual class HttpClientConnectionManager actual constructor(
 
     private val jniManager = HttpClientConnectionManagerJni.create(options.into())
 
+    public actual val managerMetrics: HttpManagerMetrics
+        get() {
+            val jniMetrics = jniManager.managerMetrics
+            return HttpManagerMetrics(
+                availableConcurrency = jniMetrics.availableConcurrency,
+                pendingConcurrencyAcquires = jniMetrics.pendingConcurrencyAcquires,
+                leasedConcurrency = jniMetrics.leasedConcurrency,
+            )
+        }
+
     /**
      * Request an HttpClientConnection from the pool
      */

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManagerNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/http/HttpClientConnectionManagerNative.kt
@@ -11,6 +11,9 @@ import aws.sdk.kotlin.crt.Closeable
 public actual class HttpClientConnectionManager actual constructor(
     public actual val options: HttpClientConnectionManagerOptions,
 ) : Closeable, AsyncShutdown {
+    public actual val managerMetrics: HttpManagerMetrics
+        get() = TODO("Not yet implemented")
+
     /**
      * Request an HttpClientConnection from the pool
      */


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/smithy-kotlin/issues/893

*Description of changes:*

This change makes HTTP manager metrics available in the Kotlin API.

**Companion PR**: https://github.com/awslabs/smithy-kotlin/pull/1017

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
