### PR TITLE
chore: relocate brazil transform

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": {
+    "org.jetbrains.kotlin:kotlin-stdlib-common:1.9.*": "KotlinStdlibCommon-1.9.x",
+    "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.*": "KotlinStdlibJdk8-1.9.x",
+    "org.jetbrains.kotlin:kotlin-stdlib:1.9.*": "KotlinStdlib-1.9.x",
+    "org.jetbrains.kotlinx:atomicfu-jvm:0.23.1": "AtomicfuJvm-0.23.1",
+    "org.jetbrains.kotlinx:atomicfu:0.23.1": "Atomicfu-0.23.1",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.*": "KotlinxCoroutinesCoreJvm-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.*": "KotlinxCoroutinesCore-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.*": "KotlinxCoroutinesJdk8-1.7.x",
+    "software.amazon.awssdk.crt:aws-crt:0.*": "Aws-crt-java-1.0.x"
+  },
+  "packageHandlingRules": {
+    "versioning": {
+      "defaultVersionLayout": "{MAJOR}.{MINOR}.x"
+    },
+    "rename": {
+      "aws.sdk.kotlin.crt:aws-crt-kotlin": "AwsCrtKotlin"
+    },
+    "ignore": [
+        "aws.sdk.kotlin.crt:aws-crt-kotlin-android"
+    ],
+    "resolvesConflictDependencies": {
+      "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.*": [
+        "KotlinStdlibCommon-1.9.x",
+        "KotlinStdlibJdk8-1.9.x"
+      ],
+      "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.*": [
+        "KotlinStdlibJdk8-1.9.x"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**refactor**: Add a new `.brazil.json` file with the transform logic for just `aws-sdk-kotlin`. **NOTE**: This will not take effect until we release a new version of `kat` and update the release pipeline to use it. Until then the "global" transform config from repo tools is still the one being used. I tested this locally already and diffed the transform output using the one from repo tools and this new localized copy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
