### PR TITLE
feat: add `toBuilder` and S3 Express signing algorithm

### DIFF
--- a/.changes/87608337-174a-46aa-add3-8ec1370c737c.json
+++ b/.changes/87608337-174a-46aa-add3-8ec1370c737c.json
@@ -1,0 +1,5 @@
+{
+    "id": "87608337-174a-46aa-add3-8ec1370c737c",
+    "type": "feature",
+    "description": "Add SIGV4_S3EXPRESS signing algorithm and AwsSigningConfig.toBuilder function"
+}

--- a/aws-crt-kotlin/api/android/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/android/aws-crt-kotlin.api
@@ -319,6 +319,7 @@ public final class aws/sdk/kotlin/crt/auth/signing/AwsSigner {
 public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm : java/lang/Enum {
 	public static final field SIGV4 Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
 	public static final field SIGV4_ASYMMETRIC Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static final field SIGV4_S3EXPRESS Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getValue ()I
 	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
@@ -342,6 +343,7 @@ public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig {
 	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
 	public final fun getSignedBodyValue ()Ljava/lang/String;
 	public final fun getUseDoubleUriEncode ()Z
+	public final fun toBuilder ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder;
 }
 
 public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder {

--- a/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/jvm/aws-crt-kotlin.api
@@ -319,6 +319,7 @@ public final class aws/sdk/kotlin/crt/auth/signing/AwsSigner {
 public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm : java/lang/Enum {
 	public static final field SIGV4 Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
 	public static final field SIGV4_ASYMMETRIC Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
+	public static final field SIGV4_S3EXPRESS Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getValue ()I
 	public static fun valueOf (Ljava/lang/String;)Laws/sdk/kotlin/crt/auth/signing/AwsSigningAlgorithm;
@@ -342,6 +343,7 @@ public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig {
 	public final fun getSignedBodyHeader ()Laws/sdk/kotlin/crt/auth/signing/AwsSignedBodyHeaderType;
 	public final fun getSignedBodyValue ()Ljava/lang/String;
 	public final fun getUseDoubleUriEncode ()Z
+	public final fun toBuilder ()Laws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder;
 }
 
 public final class aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig$Builder {

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/auth/signing/AwsSigningConfig.kt
@@ -12,6 +12,7 @@ import aws.sdk.kotlin.crt.auth.credentials.CredentialsProvider
 public enum class AwsSigningAlgorithm(public val value: Int) {
     SIGV4(0),
     SIGV4_ASYMMETRIC(1),
+    SIGV4_S3EXPRESS(2),
 }
 
 public enum class AwsSignatureType(public val value: Int) {
@@ -175,5 +176,22 @@ public class AwsSigningConfig(builder: Builder) {
         public var expirationInSeconds: Long = 0
 
         public fun build(): AwsSigningConfig = AwsSigningConfig(this)
+    }
+
+    public fun toBuilder(): Builder = Builder().apply {
+        region = this@AwsSigningConfig.region
+        service = this@AwsSigningConfig.service
+        date = this@AwsSigningConfig.date
+        algorithm = this@AwsSigningConfig.algorithm
+        shouldSignHeader = this@AwsSigningConfig.shouldSignHeader
+        signatureType = this@AwsSigningConfig.signatureType
+        useDoubleUriEncode = this@AwsSigningConfig.useDoubleUriEncode
+        normalizeUriPath = this@AwsSigningConfig.normalizeUriPath
+        omitSessionToken = this@AwsSigningConfig.omitSessionToken
+        signedBodyValue = this@AwsSigningConfig.signedBodyValue
+        signedBodyHeader = this@AwsSigningConfig.signedBodyHeader
+        credentials = this@AwsSigningConfig.credentials
+        credentialsProvider = this@AwsSigningConfig.credentialsProvider
+        expirationInSeconds = this@AwsSigningConfig.expirationInSeconds
     }
 }


### PR DESCRIPTION
Add some features related to implementation of S3 Express support:
- Add `SIGV4_S3EXPRESS` signing algorithm
- Add `toBuilder` utility function to `AwsSigningConfig`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
