### PR TITLE
fix: use same toolchain on arm that k/n does

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,3 +103,7 @@ aws_use_package(aws-c-http)
 aws_use_package(aws-c-auth)
 aws_use_package(aws-checksums)
 
+# TODO - bundling static libraries into single static library composed of all the static libraries
+# to enable IPO/LTO. See also:
+# * https://cristianadam.eu/20190501/bundling-together-static-libraries-with-cmake/
+# * https://cmake.org/cmake/help/latest/module/CheckIPOSupported.html

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -25,7 +25,7 @@ version = sdkVersion
 description = "Kotlin Multiplatform bindings for AWS SDK Common Runtime"
 
 // See: https://kotlinlang.org/docs/reference/opt-in-requirements.html#opting-in-to-using-api
-val optinAnnotations = listOf("kotlin.RequiresOptIn")
+val optinAnnotations = listOf("kotlin.RequiresOptIn", "kotlinx.cinterop.ExperimentalForeignApi")
 
 // KMP configuration from build plugin
 configureKmpTargets()

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.crt.CMakeBuildType
 import aws.sdk.kotlin.gradle.crt.cmakeInstallDir
 import aws.sdk.kotlin.gradle.crt.configureCrtCMakeBuild
 import aws.sdk.kotlin.gradle.crt.disableCrossCompileTargets
@@ -136,7 +137,7 @@ kotlin {
     targets.withType<KotlinNativeTarget> {
         val knTarget = this
         logger.info("configuring $knTarget: ${knTarget.name}")
-        val cmakeInstallTask = configureCrtCMakeBuild(knTarget)
+        val cmakeInstallTask = configureCrtCMakeBuild(knTarget, CMakeBuildType.Release)
         val targetInstallDir = project.cmakeInstallDir(knTarget)
         val headerDir = targetInstallDir.resolve("include")
         val libDir = targetInstallDir.resolve("lib")
@@ -148,6 +149,7 @@ kotlin {
                 defFile("$interopDir/crt.def")
                 includeDirs(headerDir)
                 compilerOpts("-L${libDir.absolutePath}")
+                extraOpts("-libraryPath", libDir.absolutePath)
             }
 
             // cinterop tasks processes header files which requires the corresponding CMake build/install to run
@@ -158,6 +160,7 @@ kotlin {
         }
 
         compilations["test"].compilerOptions.configure {
+            // TODO - can we remove this if we are bundling the static libs
             freeCompilerArgs.addAll(listOf("-linker-options", "-L${libDir.absolutePath}"))
         }
     }

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -11,6 +11,7 @@ import aws.sdk.kotlin.gradle.kmp.IDEA_ACTIVE
 import aws.sdk.kotlin.gradle.kmp.configureKmpTargets
 import aws.sdk.kotlin.gradle.util.typedProp
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.KonanTarget
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)

--- a/aws-crt-kotlin/native/interop/crt.def
+++ b/aws-crt-kotlin/native/interop/crt.def
@@ -8,6 +8,15 @@ headers = aws/common/allocator.h aws/common/error.h \
         aws/compression/compression.h
 headerFilter = aws/common/* aws/io/* aws/http/* aws/compression/*
 
+staticLibraries = libaws-c-common.a \
+        libaws-c-cal.a \
+        libaws-c-io.a \
+        libaws-c-compression.a \
+        libaws-c-sdkutils.a \
+        libaws-c-http.a \
+        libaws-c-auth.a \
+        libaws-checksums.a
+staticLibraries.linux = libs2n.a
 linkerOpts = -laws-c-common -laws-c-cal -laws-c-io -laws-c-http -laws-c-compression
 linkerOpts.osx = -framework Security
 linkerOpts.linux = -ls2n -lcrypto

--- a/aws-crt-kotlin/native/interop/crt.def
+++ b/aws-crt-kotlin/native/interop/crt.def
@@ -8,6 +8,13 @@ headers = aws/common/allocator.h aws/common/error.h \
         aws/compression/compression.h
 headerFilter = aws/common/* aws/io/* aws/http/* aws/compression/*
 
+# FIXME - not supported?
+#compilerOpts.linux_arm64 = -moutline-atomics
+
+linkerOpts = -laws-c-common -laws-c-cal -laws-c-io -laws-c-http -laws-c-compression
+linkerOpts.osx = -framework Security
+linkerOpts.linux = -ls2n -lcrypto
+
 staticLibraries = libaws-c-common.a \
         libaws-c-cal.a \
         libaws-c-io.a \
@@ -16,10 +23,8 @@ staticLibraries = libaws-c-common.a \
         libaws-c-http.a \
         libaws-c-auth.a \
         libaws-checksums.a
-staticLibraries.linux = libs2n.a
-linkerOpts = -laws-c-common -laws-c-cal -laws-c-io -laws-c-http -laws-c-compression
-linkerOpts.osx = -framework Security
-linkerOpts.linux = -ls2n -lcrypto
+
+staticLibraries.linux = libs2n.a libcrypto.a
 
 ---
 

--- a/aws-crt-kotlin/native/interop/crt.def
+++ b/aws-crt-kotlin/native/interop/crt.def
@@ -8,9 +8,6 @@ headers = aws/common/allocator.h aws/common/error.h \
         aws/compression/compression.h
 headerFilter = aws/common/* aws/io/* aws/http/* aws/compression/*
 
-# FIXME - not supported?
-#compilerOpts.linux_arm64 = -moutline-atomics
-
 linkerOpts = -laws-c-common -laws-c-cal -laws-c-io -laws-c-http -laws-c-compression
 linkerOpts.osx = -framework Security
 linkerOpts.linux = -ls2n -lcrypto

--- a/docker-images/linux-arm64/Dockerfile
+++ b/docker-images/linux-arm64/Dockerfile
@@ -1,2 +1,2 @@
-FROM dockcross/linux-arm64:20240104-6eda627
+FROM dockcross/manylinux2014-aarch64:20240104-6eda627
 ENV DEFAULT_DOCKCROSS_IMAGE aws-crt-kotlin/linux-arm64:latest

--- a/docker-images/linux-arm64/Dockerfile
+++ b/docker-images/linux-arm64/Dockerfile
@@ -1,2 +1,11 @@
 FROM dockcross/manylinux2014-aarch64:20240104-6eda627
 ENV DEFAULT_DOCKCROSS_IMAGE aws-crt-kotlin/linux-arm64:latest
+
+RUN curl -LJo konan-toolchain.tar.gz https://download.jetbrains.com/kotlin/native/aarch64-unknown-linux-gnu-gcc-8.3.0-glibc-2.25-kernel-4.9-2.tar.gz
+# Remove the cross compile root from the original image and put our own one based
+# on the K/N toolchain.
+RUN mv /usr/xcc/aarch64-unknown-linux-gnu /tmp/original && \
+    mkdir -p /usr/xcc/aarch64-unknown-linux-gnu && \
+    tar -xzf konan-toolchain.tar.gz -C /usr/xcc/aarch64-unknown-linux-gnu --strip-components=1 && \
+    cp /tmp/original/Toolchain.cmake /usr/xcc/aarch64-unknown-linux-gnu && \
+    rm -rf /tmp/original

--- a/docker-images/linux-x64/Dockerfile
+++ b/docker-images/linux-x64/Dockerfile
@@ -1,2 +1,6 @@
-FROM dockcross/linux-x64:20240104-6eda627
+# We need glibc <= 2.19, see https://youtrack.jetbrains.com/issue/KT-47061
+# TODO - explore creating a custom image using the same toolchain K/N uses
+# see https://github.com/JetBrains/kotlin/tree/master/kotlin-native/tools/toolchain_builder
+# OR via https://download.jetbrains.com/kotlin/native/x86_64-unknown-linux-gnu-gcc-8.3.0-glibc-2.19-kernel-4.9-2.tar.gz
+FROM dockcross/manylinux2014-x64:20240104-6eda627
 ENV DEFAULT_DOCKCROSS_IMAGE aws-crt-kotlin/linux-x64:latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
K/N toolchain uses glibc version 2.19 whereas the version we were using was 2.31 or thereabouts which are not compatible. This is fixed by leveraging the manlinux image. 


Additionally on arm64 CRT was adding the `-moutline-atomics` compiler flag which is added by [AwsCFlags ](https://github.com/awslabs/aws-c-common/blob/main/cmake/AwsCFlags.cmake#L124-L144). It would seem K/N version of gcc toolchain is too old:

```
Exception in thread "main" java.lang.Error: error: unknown argument: '-moutline-atomics'
        at org.jetbrains.kotlin.native.interop.indexer.UtilsKt.ensureNoCompileErrors(Utils.kt:275)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.indexDeclarations(Indexer.kt:1246)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.buildNativeIndexImpl(Indexer.kt:1229)
        at org.jetbrains.kotlin.native.interop.indexer.IndexerKt.buildNativeIndexImpl(Indexer.kt:1225)
        at org.jetbrains.kotlin.native.interop.gen.jvm.DefaultPlugin.buildNativeIndex(Plugins.kt:33)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.processCLib(main.kt:311)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.processCLibSafe(main.kt:243)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.access$processCLibSafe(main.kt:1)
        at org.jetbrains.kotlin.native.interop.gen.jvm.Interop.interop(main.kt:101)
        at org.jetbrains.kotlin.cli.utilities.InteropCompilerKt.invokeInterop(InteropCompiler.kt:47)
        at org.jetbrains.kotlin.cli.utilities.MainKt.mainImpl(main.kt:23)
        at org.jetbrains.kotlin.cli.utilities.MainKt.main(main.kt:45)
```


```

> cat test.c

int main() {
        int x = 1;
        __atomic_fetch_add(&x, -1, __ATOMIC_SEQ_CST);
        return x;
}

> ~/.konan/dependencies/aarch64-unknown-linux-gnu-gcc-8.3.0-glibc-2.25-kernel-4.9-2/bin/aarch64-unknown-linux-gnu-gcc -moutline-atomics test.c
aarch64-unknown-linux-gnu-gcc: error: unrecognized command line option '-moutline-atomics'; did you mean '-finline-atomics'?
```

There is no flag to disable or force CRT here so our only "quick" recourse is to instead just leverage the same toolchain that K/N is using (we could probably do this for both linuxX64 and linuxArm64) so that the `HAS_MOUTLINE_ATOMICS` flag gets set appropriately for CRT CMake build.

These changes should allow linux targets to be built and test now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
