### PR TITLE
fix: iOS simulator TLS negotiation errors

### DIFF
--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -172,6 +172,7 @@ kotlin {
 // ourselves (booting / shutting down). FIXME: https://youtrack.jetbrains.com/issue/KT-38317
 kotlin {
     val simulatorDeviceName = project.findProperty("iosSimulatorDevice") as? String ?: "iPhone 15"
+
     tasks.register<Exec>("bootIosSimulatorDevice") {
         commandLine("xcrun", "simctl", "boot", simulatorDeviceName)
 

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -173,8 +173,10 @@ kotlin {
 kotlin {
     val simulatorDeviceName = project.findProperty("iosSimulatorDevice") as? String ?: "iPhone 15"
 
+    val xcrun = "/usr/bin/xcrun"
+
     tasks.register<Exec>("bootIosSimulatorDevice") {
-        commandLine("xcrun", "simctl", "boot", simulatorDeviceName)
+        commandLine(xcrun, "simctl", "boot", simulatorDeviceName)
 
         doLast {
             val result = executionResult.get()
@@ -187,7 +189,7 @@ kotlin {
 
     tasks.register<Exec>("shutdownIosSimulatorDevice") {
         mustRunAfter(tasks.withType<KotlinNativeSimulatorTest>())
-        commandLine("xcrun", "simctl", "shutdown", simulatorDeviceName)
+        commandLine(xcrun, "simctl", "shutdown", simulatorDeviceName)
 
         doLast {
             executionResult.get().assertNormalExitValue()
@@ -195,6 +197,10 @@ kotlin {
     }
 
     tasks.withType<KotlinNativeSimulatorTest>().configureEach {
+        if (targetName?.startsWith("ios") == false) {
+            return@configureEach
+        }
+
         dependsOn("bootIosSimulatorDevice")
         finalizedBy("shutdownIosSimulatorDevice")
 

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -186,6 +186,7 @@ kotlin {
     }
 
     tasks.register<Exec>("shutdownIosSimulatorDevice") {
+        mustRunAfter(tasks.withType<KotlinNativeSimulatorTest>())
         commandLine("xcrun", "simctl", "shutdown", simulatorDeviceName)
 
         doLast {
@@ -195,7 +196,7 @@ kotlin {
 
     tasks.withType<KotlinNativeSimulatorTest>().configureEach {
         dependsOn("bootIosSimulatorDevice")
-//        finalizedBy("shutdownIosSimulatorDevice")
+        finalizedBy("shutdownIosSimulatorDevice")
 
         standalone = false
         device = simulatorDeviceName

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -12,6 +12,7 @@ import aws.sdk.kotlin.gradle.kmp.configureKmpTargets
 import aws.sdk.kotlin.gradle.util.typedProp
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
+import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -197,11 +198,7 @@ kotlin {
     }
 
     tasks.withType<KotlinNativeSimulatorTest>().configureEach {
-        if (targetName?.startsWith("ios") == false) {
-            return@configureEach
-        }
-
-        println("configuring standalone=false for task with targetName $targetName")
+        if (!HostManager.hostIsMac) { return@configureEach }
 
         dependsOn("bootIosSimulatorDevice")
         finalizedBy("shutdownIosSimulatorDevice")

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -201,6 +201,8 @@ kotlin {
             return@configureEach
         }
 
+        println("configuring standalone=false for task with targetName $targetName")
+
         dependsOn("bootIosSimulatorDevice")
         finalizedBy("shutdownIosSimulatorDevice")
 

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -178,7 +178,7 @@ kotlin {
         doLast {
             val result = executionResult.get()
             val code = result.exitValue
-            if (code != 148 && code != 149) {
+            if (code != 148 && code != 149) { // ignore "simulator already running" errors
                 result.assertNormalExitValue()
             }
         }

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -195,7 +195,7 @@ kotlin {
 
     tasks.withType<KotlinNativeSimulatorTest>().configureEach {
         dependsOn("bootIosSimulatorDevice")
-        finalizedBy("shutdownIosSimulatorDevice")
+//        finalizedBy("shutdownIosSimulatorDevice")
 
         standalone = false
         device = simulatorDeviceName


### PR DESCRIPTION
Fixes iOS simulator TLS negotiation errors by disabling `standalone` mode in simulator tests. The root cause is not known, but disabling `standalone` fixes the TLS issues. https://youtrack.jetbrains.com/issue/KT-38317.

Disabling standalone means we need to manage the simulator ourselves. This is done by registering new Gradle tasks to boot and shutdown the simulator when needed.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
