### PR TITLE
misc: upgrade to latest version of aws-crt-java

### DIFF
--- a/.changes/1803e06b-e4dc-4566-bb54-e05ff90eb5d3.json
+++ b/.changes/1803e06b-e4dc-4566-bb54-e05ff90eb5d3.json
@@ -1,0 +1,5 @@
+{
+    "id": "1803e06b-e4dc-4566-bb54-e05ff90eb5d3",
+    "type": "misc",
+    "description": "Upgrade to aws-crt-java v0.29.25"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.iml
 .idea/
 local.properties
+*.klib

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ allprojects {
         mavenLocal()
         mavenCentral()
     }
+
+    // Enables running `./gradlew allDeps` to get a comprehensive list of dependencies for every subproject
+    tasks.register<DependencyReportTask>("allDeps") { }
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin-version = "1.9.21"
 aws-kotlin-repo-tools-version = "0.4.9"
 
 # libs
-crt-java-version = "0.29.6"
+crt-java-version = "0.29.25"
 coroutines-version = "1.7.3"
 
 # testing


### PR DESCRIPTION
Upgrade to the latest version of aws-crt-java which [recently added support for GraalVM](https://github.com/awslabs/aws-crt-java/pull/791)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
