### PR TITLE
fix: upgrade CRT version to pick up header signing changes

### DIFF
--- a/.changes/a070184a-04e1-46b7-bbb7-73d7cf95b495.json
+++ b/.changes/a070184a-04e1-46b7-bbb7-73d7cf95b495.json
@@ -1,0 +1,5 @@
+{
+    "id": "a070184a-04e1-46b7-bbb7-73d7cf95b495",
+    "type": "bugfix",
+    "description": "Upgrade to latest version of CRT to pick up header signing changes"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin-version = "2.1.0"
 aws-kotlin-repo-tools-version = "0.4.17"
 
 # libs
-crt-java-version = "0.33.7"
+crt-java-version = "0.33.10"
 coroutines-version = "1.9.0"
 binary-compatibility-validator-version = "0.16.3"
 


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Upgrade to the latest CRT release to pick up [changes to skip signing `Transfer-Encoding` header](https://github.com/awslabs/aws-c-auth/pull/261).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
