### PR TITLE
kn: make `log` public for CrtLogger

### DIFF
--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/Logging.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/Logging.kt
@@ -71,6 +71,6 @@ internal object Logging {
     }
 }
 
-internal inline fun log(level: LogLevel, message: String, subject: aws_log_subject_t = AWS_LS_KOTLIN_CRT_GENERAL) {
+public inline fun log(level: LogLevel, message: String, subject: aws_log_subject_t = AWS_LS_KOTLIN_CRT_GENERAL) {
     s_crt_kotlin_log(level.value.convert(), subject, message)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Makes `log` function public to allow its use in smithy-kotlin's `CrtLogger`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
