### PR TITLE
chore: upgrade aws-kotlin-repo-tools

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.1.0"
 
-aws-kotlin-repo-tools-version = "0.4.20"
+aws-kotlin-repo-tools-version = "0.4.22"
 
 # libs
 crt-java-version = "0.33.10"


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Upgrade **aws-kotlin-repo-tools** to **0.4.22** to pick up [fix for compiler warning](https://github.com/awslabs/aws-kotlin-repo-tools/pull/82).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
