### PR TITLE
fix: update supported TLS cipher preferences

### DIFF
--- a/.changes/3d6fffae-2ce4-478f-b410-fce0afe16588.json
+++ b/.changes/3d6fffae-2ce4-478f-b410-fce0afe16588.json
@@ -1,0 +1,5 @@
+{
+    "id": "3d6fffae-2ce4-478f-b410-fce0afe16588",
+    "type": "bugfix",
+    "description": "Update the set of supported `TlsCipherPreference` values to reflect the latest capabilities/support from CRT"
+}

--- a/aws-crt-kotlin/api/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/aws-crt-kotlin.api
@@ -815,6 +815,8 @@ public final class aws/sdk/kotlin/crt/io/TlsCipherPreference : java/lang/Enum {
 	public static final field KMS_PQ_TLS_V1_0_2019_06 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field KMS_PQ_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field KMS_PQ_TLS_V1_0_2020_07 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field PQ_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
+	public static final field PQ_TLSV1_2_2024_10 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field PQ_TLS_V1_0_2021_05 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field SYSTEM_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/TlsCipherPreference.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/TlsCipherPreference.kt
@@ -19,54 +19,53 @@ public enum class TlsCipherPreference(public val value: Int) {
     SYSTEM_DEFAULT(0),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.")
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     KMS_PQ_TLS_V1_0_2019_06(1),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.")
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     KMS_PQ_SIKE_TLS_V1_0_2019_11(2),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.")
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     KMS_PQ_TLS_V1_0_2020_02(3),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.")
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     KMS_PQ_SIKE_TLS_V1_0_2020_02(4),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLS_V1_0_2021_05 instead.")
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     KMS_PQ_TLS_V1_0_2020_07(5),
 
     /**
-     * This TlsCipherPreference supports TLS 1.0 through TLS 1.3, and contains Kyber Round 3 as its highest priority
-     * PQ algorithm. PQ algorithms in this preference list will be used in hybrid mode, and will be combined with a
-     * classical ECDHE key exchange.
-     *
-     * NIST has announced that Kyber will be first post-quantum key-agreement algorithm that it will standardize.
-     * However, the NIST standardization process might introduce minor changes that may cause the final Kyber standard
-     * to differ from the Kyber Round 3 implementation available in this preference list.
-     *
-     * Since this TlsCipherPreference contains algorithms that have not yet been officially standardized by NIST, this
-     * preference list, and any of the PQ algorithms in it, may stop being supported at any time.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design
-     *   - https://aws.amazon.com/blogs/security/how-to-tune-tls-for-hybrid-post-quantum-cryptography-with-kyber/
-     *   - https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413.pdf
+     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
      */
+    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
     PQ_TLS_V1_0_2021_05(6),
+
+    /**
+     * This TLS cipher preference list contains post-quantum key exchange algorithms that have been standardized by
+     * NIST. PQ algorithms in this preference list will be used in hybrid mode, and always combined with a classical
+     * ECDHE key exchange.
+     */
+    PQ_TLSV1_2_2024_10(7),
+
+    /**
+     * Recommended default policy with post-quantum algorithm support. This policy may change over time.
+     */
+    PQ_DEFAULT(8),
+
     ;
 
     /**

--- a/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/TlsContextJVM.kt
+++ b/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/TlsContextJVM.kt
@@ -36,6 +36,8 @@ private fun TlsCipherPreference.into(): TlsCipherPreferenceJni = when (this) {
     TlsCipherPreference.KMS_PQ_SIKE_TLS_V1_0_2020_02 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02
     TlsCipherPreference.KMS_PQ_TLS_V1_0_2020_07 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_07
     TlsCipherPreference.PQ_TLS_V1_0_2021_05 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05
+    TlsCipherPreference.PQ_TLSV1_2_2024_10 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_PQ_TLSv1_2_2023
+    TlsCipherPreference.PQ_DEFAULT -> TlsCipherPreferenceJni.TLS_CIPHER_PQ_DEFAULT
 }
 
 private fun TlsVersion.into(): TlsVersionJni = when (this) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin-version = "2.1.0"
 aws-kotlin-repo-tools-version = "0.4.22"
 
 # libs
-crt-java-version = "0.33.10"
+crt-java-version = "0.38.1"
 coroutines-version = "1.9.0"
 binary-compatibility-validator-version = "0.16.3"
 


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Updates the list of supported cipher preferences to match [what CRT supports](https://github.com/awslabs/aws-c-io/blob/8286c781b95b426ca2f0783b6c1fe49ff519c4e7/include/aws/io/tls_channel_handler.h#L30-L47), specifically:
* Adds support for `PQ_TLSV1_2_2024_10` and `PQ_DEFAULT`
* Deprecates `PQ_TLS_V1_0_2021_05`
* Updates **aws-crt-java** version to [**v0.38.1**](https://github.com/awslabs/aws-crt-java/releases/tag/v0.38.1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
