### PR TITLE
misc: force commons-beanutils to 1.11.0

### DIFF
--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -53,5 +53,15 @@ kotlin {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        /*
+         FIXME: Remove this when "org.mock-server:mockserver-netty" releases a version that depends on
+         "commons-beanutils:commons-beanutils:1.11.0" or higher
+         */
+        force("commons-beanutils:commons-beanutils:1.11.0")
+    }
+}
+
 // Publishing
 configurePublishing("aws-crt-kotlin")


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/aws-crt-kotlin/security/dependabot/28

*Description of changes:*
We're already using the [latest](https://mvnrepository.com/artifact/org.mock-server/mockserver-netty) [version](https://github.com/awslabs/aws-crt-kotlin/blob/main/gradle/libs.versions.toml#L14) of Netty. Which relies on vulnerable version of beanutils. We need to force the resolution strategy to use a non-vulnerable version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
