### PR TITLE
misc: add `-Xjdk-release=1.8` everywhere we set `jvmTarget`

### DIFF
--- a/.changes/aa10152c-0040-46b3-8551-ed63aca0c6ee.json
+++ b/.changes/aa10152c-0040-46b3-8551-ed63aca0c6ee.json
@@ -1,0 +1,8 @@
+{
+    "id": "aa10152c-0040-46b3-8551-ed63aca0c6ee",
+    "type": "bugfix",
+    "description": "Enable building this project on JDK21 by setting -Xjdk-release flag",
+    "issues": [
+        "https://github.com/smithy-lang/smithy-kotlin/issues/1295"
+    ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ subprojects {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            freeCompilerArgs.add("-Xjdk-release=1.8")
             freeCompilerArgs.add("-Xexpect-actual-classes")
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

Addresses https://github.com/smithy-lang/smithy-kotlin/issues/1295

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
