### PR TITLE
chore: remove `@Deprecated` APIs in preparation for v1.5

### DIFF
--- a/aws-crt-kotlin/api/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/aws-crt-kotlin.api
@@ -810,14 +810,8 @@ public final class aws/sdk/kotlin/crt/io/SocketType : java/lang/Enum {
 }
 
 public final class aws/sdk/kotlin/crt/io/TlsCipherPreference : java/lang/Enum {
-	public static final field KMS_PQ_SIKE_TLS_V1_0_2019_11 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
-	public static final field KMS_PQ_SIKE_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
-	public static final field KMS_PQ_TLS_V1_0_2019_06 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
-	public static final field KMS_PQ_TLS_V1_0_2020_02 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
-	public static final field KMS_PQ_TLS_V1_0_2020_07 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field PQ_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field PQ_TLSV1_2_2024_10 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
-	public static final field PQ_TLS_V1_0_2021_05 Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static final field SYSTEM_DEFAULT Laws/sdk/kotlin/crt/io/TlsCipherPreference;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getValue ()I

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/TlsCipherPreference.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/TlsCipherPreference.kt
@@ -19,42 +19,6 @@ public enum class TlsCipherPreference(public val value: Int) {
     SYSTEM_DEFAULT(0),
 
     /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    KMS_PQ_TLS_V1_0_2019_06(1),
-
-    /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    KMS_PQ_SIKE_TLS_V1_0_2019_11(2),
-
-    /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    KMS_PQ_TLS_V1_0_2020_02(3),
-
-    /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    KMS_PQ_SIKE_TLS_V1_0_2020_02(4),
-
-    /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    KMS_PQ_TLS_V1_0_2020_07(5),
-
-    /**
-     * This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.
-     */
-    @Deprecated("This cipher preference is no longer supported. Use PQ_TLSV1_2_2024_10 instead.")
-    PQ_TLS_V1_0_2021_05(6),
-
-    /**
      * This TLS cipher preference list contains post-quantum key exchange algorithms that have been standardized by
      * NIST. PQ algorithms in this preference list will be used in hybrid mode, and always combined with a classical
      * ECDHE key exchange.

--- a/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/TlsContextJVM.kt
+++ b/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/TlsContextJVM.kt
@@ -27,15 +27,8 @@ internal actual fun isCipherSupported(cipher: TlsCipherPreference): Boolean =
 
 internal actual fun isAlpnSupported(): Boolean = TlsContextOptionsJni.isAlpnSupported()
 
-@Suppress("DEPRECATION")
 private fun TlsCipherPreference.into(): TlsCipherPreferenceJni = when (this) {
     TlsCipherPreference.SYSTEM_DEFAULT -> TlsCipherPreferenceJni.TLS_CIPHER_SYSTEM_DEFAULT
-    TlsCipherPreference.KMS_PQ_TLS_V1_0_2019_06 -> TlsCipherPreferenceJni.TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06
-    TlsCipherPreference.KMS_PQ_SIKE_TLS_V1_0_2019_11 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2019_11
-    TlsCipherPreference.KMS_PQ_TLS_V1_0_2020_02 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_02
-    TlsCipherPreference.KMS_PQ_SIKE_TLS_V1_0_2020_02 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02
-    TlsCipherPreference.KMS_PQ_TLS_V1_0_2020_07 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_07
-    TlsCipherPreference.PQ_TLS_V1_0_2021_05 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05
     TlsCipherPreference.PQ_TLSV1_2_2024_10 -> TlsCipherPreferenceJni.TLS_CIPHER_PREF_PQ_TLSv1_2_2023
     TlsCipherPreference.PQ_DEFAULT -> TlsCipherPreferenceJni.TLS_CIPHER_PQ_DEFAULT
 }


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Removes `@Deprecated` APIs from the runtime modules in preparation for **v1.5** release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.