### PR TITLE
fix: remove unnecessary `-jvm-default=no-compatibility` compiler flag

### DIFF
--- a/aws-crt-kotlin/api/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/aws-crt-kotlin.api
@@ -412,6 +412,12 @@ public final class aws/sdk/kotlin/crt/http/Headers$Companion {
 	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/sdk/kotlin/crt/http/Headers;
 }
 
+public final class aws/sdk/kotlin/crt/http/Headers$DefaultImpls {
+	public static fun contains (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;Ljava/lang/String;)Z
+	public static fun forEach (Laws/sdk/kotlin/crt/http/Headers;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/sdk/kotlin/crt/http/Headers;Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class aws/sdk/kotlin/crt/http/HeadersBuilder {
 	public fun <init> ()V
 	public final fun append (Ljava/lang/String;Ljava/lang/String;)V
@@ -618,6 +624,11 @@ public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$Companion {
 	public final fun fromByteArray ([B)Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;
 }
 
+public final class aws/sdk/kotlin/crt/http/HttpRequestBodyStream$DefaultImpls {
+	public static fun resetPosition (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;)Z
+	public static fun sendRequestBody (Laws/sdk/kotlin/crt/http/HttpRequestBodyStream;Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
 public final class aws/sdk/kotlin/crt/http/HttpRequestBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/crt/http/HttpRequest;
@@ -676,6 +687,12 @@ public abstract interface class aws/sdk/kotlin/crt/http/HttpStreamResponseHandle
 	public fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStream;I)V
 }
 
+public final class aws/sdk/kotlin/crt/http/HttpStreamResponseHandler$DefaultImpls {
+	public static fun onMetrics (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/http/HttpStreamMetrics;)V
+	public static fun onResponseBody (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;Laws/sdk/kotlin/crt/io/Buffer;)I
+	public static fun onResponseHeadersDone (Laws/sdk/kotlin/crt/http/HttpStreamResponseHandler;Laws/sdk/kotlin/crt/http/HttpStream;I)V
+}
+
 public abstract interface class aws/sdk/kotlin/crt/io/Buffer {
 	public static final field Companion Laws/sdk/kotlin/crt/io/Buffer$Companion;
 	public abstract fun copyTo ([BI)I
@@ -686,6 +703,10 @@ public abstract interface class aws/sdk/kotlin/crt/io/Buffer {
 
 public final class aws/sdk/kotlin/crt/io/Buffer$Companion {
 	public final fun getEmpty ()Laws/sdk/kotlin/crt/io/Buffer;
+}
+
+public final class aws/sdk/kotlin/crt/io/Buffer$DefaultImpls {
+	public static synthetic fun copyTo$default (Laws/sdk/kotlin/crt/io/Buffer;[BIILjava/lang/Object;)I
 }
 
 public final class aws/sdk/kotlin/crt/io/BufferKt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ subprojects {
             jvmTarget.set(JvmTarget.JVM_1_8)
             freeCompilerArgs.add("-Xjdk-release=1.8")
             freeCompilerArgs.add("-Xexpect-actual-classes")
-            freeCompilerArgs.add("-jvm-default=no-compatibility") // https://youtrack.jetbrains.com/issue/KT-77376
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile> {


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Removes unnecessary `-jvm-default=no-compatibility` flag added in #160.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
