### PR TITLE
feat: migrate to jreleaser

### DIFF
--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 val sdkVersion: String by project
-group = properties["publishGroupName"] ?: error("missing publishGroupName")
+group = "aws.sdk.kotlin.crt"
 version = sdkVersion
 description = "Kotlin Multiplatform bindings for AWS SDK Common Runtime"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import aws.sdk.kotlin.gradle.dsl.configureLinting
-import aws.sdk.kotlin.gradle.dsl.configureNexus
+import aws.sdk.kotlin.gradle.dsl.configureJReleaser
 import aws.sdk.kotlin.gradle.util.typedProp
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -61,7 +61,7 @@ if (project.typedProp<Boolean>("kotlinWarningsAsErrors") == true) {
 }
 
 // Publishing
-configureNexus()
+configureJReleaser()
 
 // Code Style
 val lintPaths = listOf(
@@ -73,3 +73,6 @@ configureLinting(lintPaths)
 apiValidation {
     ignoredProjects += setOf("elasticurl")
 }
+
+// https://github.com/jreleaser/jreleaser/issues/1492
+tasks.register("clean") {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,3 @@ org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G
 
 # aws-crt-kotlin
 sdkVersion=0.9.3-SNAPSHOT
-
-# publishing
-publishGroupName=aws.sdk.kotlin.crt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.1.0"
 
-aws-kotlin-repo-tools-version = "0.4.32"
+aws-kotlin-repo-tools-version = "0.4.33"
 
 # libs
 crt-java-version = "0.38.1"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
- Migrated to jreleaser plugin
- Got rid of `publishGroupName` property since it was used by nexus and reused to not specify a group name in our maven publisher

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
