### PR TITLE
fix: correct Brazil transformation version mapping for CRT

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -7,7 +7,7 @@
   },
   "packageHandlingRules": {
     "versioning": {
-      "defaultVersionLayout": "{MAJOR}.{MINOR}.x"
+      "defaultVersionLayout": "{MAJOR}.x"
     },
     "rename": {
       "aws.sdk.kotlin.crt:aws-crt-kotlin": "AwsCrtKotlin"


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Update Brazil transformation rules to match other packages, namely to use `{MAJOR}.x` instead of including `{MINOR}` as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
