### PR TITLE
fix: correctly close HTTP-related CRT resources in native sourceset

### DIFF
--- a/aws-crt-kotlin/api/aws-crt-kotlin.api
+++ b/aws-crt-kotlin/api/aws-crt-kotlin.api
@@ -719,6 +719,7 @@ public final class aws/sdk/kotlin/crt/io/BufferKt {
 }
 
 public final class aws/sdk/kotlin/crt/io/ClientBootstrap : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> ()V
 	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;Laws/sdk/kotlin/crt/io/HostResolver;)V
 	public fun close ()V
 	public fun waitForShutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -733,6 +734,7 @@ public final class aws/sdk/kotlin/crt/io/EventLoopGroup : aws/sdk/kotlin/crt/Asy
 }
 
 public final class aws/sdk/kotlin/crt/io/HostResolver : aws/sdk/kotlin/crt/AsyncShutdown, aws/sdk/kotlin/crt/Closeable {
+	public fun <init> ()V
 	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;)V
 	public fun <init> (Laws/sdk/kotlin/crt/io/EventLoopGroup;I)V
 	public fun close ()V

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/ClientBootstrap.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/ClientBootstrap.kt
@@ -15,6 +15,8 @@ import aws.sdk.kotlin.crt.Closeable
 public expect class ClientBootstrap(elg: EventLoopGroup, hr: HostResolver) :
     Closeable,
     AsyncShutdown {
+    public constructor()
+
     override suspend fun waitForShutdown()
     override fun close()
 }

--- a/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/HostResolver.kt
+++ b/aws-crt-kotlin/common/src/aws/sdk/kotlin/crt/io/HostResolver.kt
@@ -14,6 +14,8 @@ public expect class HostResolver(elg: EventLoopGroup, maxEntries: Int) :
     Closeable,
     AsyncShutdown {
     public constructor(elg: EventLoopGroup)
+    public constructor()
+
     override fun close()
     override suspend fun waitForShutdown()
 }

--- a/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/HostResolverJVM.kt
+++ b/aws-crt-kotlin/jvm/src/aws/sdk/kotlin/crt/io/HostResolverJVM.kt
@@ -9,15 +9,22 @@ import aws.sdk.kotlin.crt.AsyncShutdown
 import aws.sdk.kotlin.crt.Closeable
 import software.amazon.awssdk.crt.io.HostResolver as HostResolverJni
 
-public actual class HostResolver actual constructor(elg: EventLoopGroup, maxEntries: Int) :
-    Closeable,
+public actual class HostResolver private constructor(
+    private val elg: EventLoopGroup,
+    private val manageElg: Boolean,
+    maxEntries: Int,
+) : Closeable,
     AsyncShutdown {
     internal val jniHr = HostResolverJni(elg.jniElg, maxEntries)
 
-    public actual constructor(elg: EventLoopGroup) : this(elg, DEFAULT_MAX_ENTRIES)
+    public actual constructor(elg: EventLoopGroup, maxEntries: Int) : this(elg, false, maxEntries)
+    public actual constructor(elg: EventLoopGroup) : this(elg, false, DEFAULT_MAX_ENTRIES)
+    public actual constructor() : this(EventLoopGroup(), true, DEFAULT_MAX_ENTRIES)
 
     actual override fun close() {
         jniHr.close()
+
+        if (manageElg) elg.close()
     }
 
     actual override suspend fun waitForShutdown() {

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/EventLoopGroupNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/EventLoopGroupNative.kt
@@ -5,13 +5,18 @@
 
 package aws.sdk.kotlin.crt.io
 
-import aws.sdk.kotlin.crt.*
 import aws.sdk.kotlin.crt.Allocator
+import aws.sdk.kotlin.crt.AsyncShutdown
+import aws.sdk.kotlin.crt.Closeable
+import aws.sdk.kotlin.crt.NativeHandle
 import aws.sdk.kotlin.crt.util.ShutdownChannel
 import aws.sdk.kotlin.crt.util.shutdownChannel
 import cnames.structs.aws_event_loop_group
 import kotlinx.cinterop.*
-import libcrt.*
+import libcrt.aws_event_loop_group_new
+import libcrt.aws_event_loop_group_options
+import libcrt.aws_event_loop_group_release
+import libcrt.aws_shutdown_callback_options
 
 /**
  * Creates a new event loop group for the I/O subsystem to use to run blocking I/O requests

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/HostResolverNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/HostResolverNative.kt
@@ -19,8 +19,7 @@ public actual class HostResolver private constructor(
     private val elg: EventLoopGroup,
     private val manageElg: Boolean,
     private val maxEntries: Int,
-) :
-    NativeHandle<aws_host_resolver>,
+) : NativeHandle<aws_host_resolver>,
     Closeable,
     AsyncShutdown {
 

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/HostResolverNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/HostResolverNative.kt
@@ -5,19 +5,28 @@
 
 package aws.sdk.kotlin.crt.io
 
-import aws.sdk.kotlin.crt.*
 import aws.sdk.kotlin.crt.Allocator
+import aws.sdk.kotlin.crt.AsyncShutdown
+import aws.sdk.kotlin.crt.Closeable
+import aws.sdk.kotlin.crt.NativeHandle
 import aws.sdk.kotlin.crt.util.ShutdownChannel
 import aws.sdk.kotlin.crt.util.shutdownChannel
 import kotlinx.cinterop.*
 import libcrt.*
 
 @OptIn(ExperimentalForeignApi::class)
-public actual class HostResolver actual constructor(elg: EventLoopGroup, maxEntries: Int) :
+public actual class HostResolver private constructor(
+    private val elg: EventLoopGroup,
+    private val manageElg: Boolean,
+    private val maxEntries: Int,
+) :
     NativeHandle<aws_host_resolver>,
     Closeable,
     AsyncShutdown {
-    public actual constructor(elg: EventLoopGroup) : this(elg, DEFAULT_MAX_ENTRIES)
+
+    public actual constructor(elg: EventLoopGroup, maxEntries: Int) : this(elg, false, maxEntries)
+    public actual constructor(elg: EventLoopGroup) : this(elg, false, DEFAULT_MAX_ENTRIES)
+    public actual constructor() : this(EventLoopGroup(), true, DEFAULT_MAX_ENTRIES)
 
     override val ptr: CPointer<aws_host_resolver>
 
@@ -49,6 +58,8 @@ public actual class HostResolver actual constructor(elg: EventLoopGroup, maxEntr
 
     actual override fun close() {
         aws_host_resolver_release(ptr)
+
+        if (manageElg) elg.close()
     }
 }
 

--- a/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/TlsContextNative.kt
+++ b/aws-crt-kotlin/native/src/aws/sdk/kotlin/crt/io/TlsContextNative.kt
@@ -6,8 +6,6 @@
 package aws.sdk.kotlin.crt.io
 
 import aws.sdk.kotlin.crt.*
-import aws.sdk.kotlin.crt.Allocator
-import aws.sdk.kotlin.crt.awsAssertOpSuccess
 import aws.sdk.kotlin.crt.util.asAwsByteCursor
 import aws.sdk.kotlin.crt.util.free
 import aws.sdk.kotlin.crt.util.toAwsString


### PR DESCRIPTION
*Issue #, if available:*

#96 

*Description of changes:*

This change adds child resource tracking/management for HTTP-related Kotlin/Native CRT resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
