### PR TITLE
chore: configure Windows' CI toolchain explicitly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
           msystem: MINGW64
           install: >-
             mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-toolchain
       - name: Setup build environment
         uses: ./.github/actions/setup-build
       - name: Build and Test ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Explicitly sets the entire toolchain for Windows CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
