### PR TITLE
chore: scope the stale_issue.yaml workflow to run only on this repository

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -11,6 +11,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    if: github.repository == 'aws/aws-crt-kotlin'
     steps:
     - uses: aws-actions/stale-issue-cleanup@v3
       with:


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

The stale issue cleanup workflow should be scoped to run only on this repository (and not other repos to which the workflow file may be copied).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
