### PR TITLE
Replace junit with kotlin test

### DIFF
--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2ClientConnectionTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2ClientConnectionTest.kt
@@ -13,9 +13,9 @@ import mockwebserver3.MockWebServer
 import okhttp3.Protocol
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 
@@ -24,7 +24,7 @@ class Http2ClientConnectionTest : CrtTest() {
     private lateinit var mockServer: MockWebServer
     private lateinit var serverCert: HeldCertificate
 
-    @BeforeEach
+    @BeforeTest
     fun setup() {
         serverCert = HeldCertificate.Builder()
             .commonName("localhost")
@@ -40,7 +40,7 @@ class Http2ClientConnectionTest : CrtTest() {
         mockServer.start()
     }
 
-    @AfterEach
+    @AfterTest
     fun teardown() {
         mockServer.close()
     }

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2ClientConnectionTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2ClientConnectionTest.kt
@@ -13,10 +13,10 @@ import mockwebserver3.MockWebServer
 import okhttp3.Protocol
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
+import java.util.concurrent.CompletableFuture
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 
 // TODO Relocate this to common sourceset when Native implementation is complete (also need to find a KMP mockserver dependency)

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2StreamManagerTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2StreamManagerTest.kt
@@ -15,10 +15,10 @@ import mockwebserver3.MockWebServer
 import okhttp3.Protocol
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
+import java.util.concurrent.CompletableFuture
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2StreamManagerTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/Http2StreamManagerTest.kt
@@ -15,9 +15,9 @@ import mockwebserver3.MockWebServer
 import okhttp3.Protocol
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -27,7 +27,7 @@ class Http2StreamManagerTest : CrtTest() {
     private lateinit var mockServer: MockWebServer
     private lateinit var serverCert: HeldCertificate
 
-    @BeforeEach
+    @BeforeTest
     fun setup() {
         serverCert = HeldCertificate.Builder()
             .commonName("localhost")
@@ -43,7 +43,7 @@ class Http2StreamManagerTest : CrtTest() {
         mockServer.start()
     }
 
-    @AfterEach
+    @AfterTest
     fun teardown() {
         mockServer.close()
     }

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpClientConnectionTlsTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpClientConnectionTlsTest.kt
@@ -14,9 +14,9 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
+import software.amazon.awssdk.crt.http.HttpException
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import software.amazon.awssdk.crt.http.HttpException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpClientConnectionTlsTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpClientConnectionTlsTest.kt
@@ -14,8 +14,8 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
+import kotlin.test.AfterTest
+import kotlin.test.Test
 import software.amazon.awssdk.crt.http.HttpException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -34,7 +34,7 @@ class HttpClientConnectionTlsTest : CrtTest() {
 
     private lateinit var mockServer: MockWebServer
 
-    @AfterEach
+    @AfterTest
     fun teardown() {
         mockServer.close()
     }

--- a/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpRequestResponseTest.kt
+++ b/aws-crt-kotlin/jvm/test/aws/sdk/kotlin/crt/http/HttpRequestResponseTest.kt
@@ -10,28 +10,24 @@ import aws.sdk.kotlin.crt.util.encodeToHex
 import kotlinx.coroutines.runBlocking
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.TestInstance
 import kotlin.test.*
 
 private val TEST_DOC_LINE = "This is a sample to prove that http downloads and uploads work."
 private val TEST_DOC_SHA256 = "c7fdb5314b9742467b16bd5ea2f8012190b5e2c44a005f7984f89aab58219534"
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HttpRequestResponseTest : HttpClientTest() {
 
     lateinit var mockServer: MockWebServer
     lateinit var url: String
 
-    @BeforeAll
+    @BeforeTest
     fun setup() {
         mockServer = MockWebServer()
         mockServer.start()
         url = "http://localhost:${mockServer.port}"
     }
 
-    @AfterAll
+    @AfterTest
     fun tearDown() {
         mockServer.close()
     }

--- a/build-support/build.gradle.kts
+++ b/build-support/build.gradle.kts
@@ -16,10 +16,6 @@ repositories {
 dependencies {
     compileOnly(kotlin("gradle-plugin"))
     compileOnly(kotlin("gradle-plugin-api"))
-
-    testImplementation(libs.junit.jupiter)
-    testImplementation(libs.junit.jupiter.params)
-    testImplementation(libs.kotlin.test.junit5)
 }
 
 gradlePlugin {
@@ -32,7 +28,6 @@ gradlePlugin {
 }
 
 tasks.test {
-    useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")
         showStandardStreams = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,6 @@ aws-kotlin-repo-tools-build-support = { module="aws.sdk.kotlin.gradle:build-supp
 crt-java = { module = "software.amazon.awssdk.crt:aws-crt", version.ref = "crt-java-version" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-version"}
-kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin-version" }
-
 kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "coroutines-version" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-version" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ coroutines-version = "1.10.2"
 binary-compatibility-validator-version = "0.18.1"
 
 # testing
-junit-version = "6.0.1"
 okhttp-version = "5.3.2"
 
 [libraries]
@@ -23,9 +22,6 @@ kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-version" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-version" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "coroutines-version" }
-
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-version" }
 
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp-version" }
 okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp-version" }


### PR DESCRIPTION
Replace all remaining JUnit usages with kotlin.test.
## Changes

- Replace org.junit.jupiter.api.Test, @BeforeEach, @AfterEach, @BeforeAll, @AfterAll with kotlin.test.Test, @BeforeTest, @AfterTest in JVM test files
- Remove @TestInstance(TestInstance.Lifecycle.PER_CLASS) from HttpRequestResponseTest (no longer needed — @BeforeTest/@AfterTest run per-test by default)
- Remove JUnit dependencies from build-support/build.gradle.kts (junit-jupiter, junit-jupiter-params, kotlin-test-junit5)
- Remove useJUnitPlatform() from build-support/build.gradle.kts
- Remove JUnit version catalog entries from gradle/libs.versions.toml (junit-version, junit-jupiter, junit-jupiter-params, kotlin-test-junit5)

## Notes
- The useJUnitPlatform() in aws-crt-kotlin/build.gradle.kts is intentionally kept — it's the Gradle test engine config required by kotlin.test on JVM
- JVM-only tests cannot be moved to common due to dependencies on OkHttp MockWebServer, java.nio, and JVM CRT bindings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
