### PR TITLE
Update build-all.sh to prefer docker as container management tool over finch/podman.

### DIFF
--- a/docker-images/build-all.sh
+++ b/docker-images/build-all.sh
@@ -14,12 +14,12 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PROJ_ROOT=$(realpath "$SCRIPT_DIR/..")
 
 if [ -z "$OCI_EXE" ]; then
-    if which finch > /dev/null 2>/dev/null; then
-      OCI_EXE=finch
+    if which docker >/dev/null 2>/dev/null; then
+        OCI_EXE=docker
+    elif which finch > /dev/null 2>/dev/null; then
+        OCI_EXE=finch
     elif which podman >/dev/null 2>/dev/null; then
         OCI_EXE=podman
-    elif which docker >/dev/null 2>/dev/null; then
-        OCI_EXE=docker
     else
         die "Cannot find a container executor. Search for docker and podman."
     fi


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update `build-all.sh` to prefer `docker` as container management tool over `finch`/`podman`. Tool `finch` is installed in AL 2023 by default and while executing `build-all.sh` manually, it failed with permission denied error to write to finch config.
___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
