### PR TITLE
change DWINAPI_FAMILY for DESKTOP + APP

### DIFF
--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -119,6 +119,7 @@ kotlin {
 
                 val mingwLibs = Paths.get(mingwHome, "lib").toString().replace("\\", "\\\\") // Windows path shenanigans
 
+                // WINAPI_FAMILY values defined here: https://github.com/mingw-w64/mingw-w64/blob/7c72b740e1f2c735c6e3e5f436d3056b16c616ec/mingw-w64-headers/include/winapifamily.h
                 doLast {
                     Files.writeString(
                         defPath.get().asFile.toPath(),
@@ -129,7 +130,6 @@ kotlin {
                                 -DUNICODE \
                                 -DWINVER=0x0601 \
                                 -D_WIN32_WINNT=0x0601 \
-                                # WINAPI_FAMILY values defined here: https://github.com/mingw-w64/mingw-w64/blob/7c72b740e1f2c735c6e3e5f436d3056b16c616ec/mingw-w64-headers/include/winapifamily.h
                                 -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP \
                                 -DOEMRESOURCE \
                                 -Wno-incompatible-pointer-types \

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -129,6 +129,7 @@ kotlin {
                                 -DUNICODE \
                                 -DWINVER=0x0601 \
                                 -D_WIN32_WINNT=0x0601 \
+                                # WINAPI_FAMILY values defined here: https://github.com/mingw-w64/mingw-w64/blob/7c72b740e1f2c735c6e3e5f436d3056b16c616ec/mingw-w64-headers/include/winapifamily.h
                                 -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP \
                                 -DOEMRESOURCE \
                                 -Wno-incompatible-pointer-types \

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -129,7 +129,7 @@ kotlin {
                                 -DUNICODE \
                                 -DWINVER=0x0601 \
                                 -D_WIN32_WINNT=0x0601 \
-                                -DWINAPI_FAMILY=3 \
+                                -DWINAPI_FAMILY=100 \
                                 -DOEMRESOURCE \
                                 -Wno-incompatible-pointer-types \
                                 -Wno-deprecated-declarations

--- a/aws-crt-kotlin/build.gradle.kts
+++ b/aws-crt-kotlin/build.gradle.kts
@@ -129,7 +129,7 @@ kotlin {
                                 -DUNICODE \
                                 -DWINVER=0x0601 \
                                 -D_WIN32_WINNT=0x0601 \
-                                -DWINAPI_FAMILY=100 \
+                                -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP \
                                 -DOEMRESOURCE \
                                 -Wno-incompatible-pointer-types \
                                 -Wno-deprecated-declarations


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, the number 3 we set for DWINAPI_FAMILY=3 was a bitmask, now they changed to integer constant WINAPI_FAMILY_PHONE_APP (see this [commit](https://github.com/mingw-w64/mingw-w64/commit/9f99c31b34dc0b7c865e7bd6b136980e08da3275)). This changes should bring back all functions (including `GetFileVersionInfoSizeW` and `GetFileVersionInfoW`) from `WINAPI_FAMILY_DESKTOP_APP`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
