### PR TITLE
chore: authenticate to ECR for building Docker images to reduce throttling errors; add retry to Docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
 
 permissions:
   contents: read
-  id-token: read
+  id-token: write
 
 jobs:
   jvm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,11 +95,27 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+
       - name: Setup build environment
         uses: ./.github/actions/setup-build
+
       - name: Configure Docker Images
-        run: |
-          ./docker-images/build-images.sh linux-x64 linux-arm64
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: |
+            ./docker-images/build-images.sh linux-x64 linux-arm64
+          on_retry_command: |
+            echo "Docker image build failed. Waiting for 10s before trying again..."
+            sleep 10          
+
       - name: Build and Test ${{ env.PACKAGE_NAME }}
         run: |
           ./gradlew build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,7 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
+          timeout_minutes: 30
           command: |
             ./docker-images/build-images.sh linux-x64 linux-arm64
           on_retry_command: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ env:
 
 permissions:
   contents: read
+  id-token: read
 
 jobs:
   jvm:
@@ -114,7 +115,7 @@ jobs:
             ./docker-images/build-images.sh linux-x64 linux-arm64
           on_retry_command: |
             echo "Docker image build failed. Waiting for 10s before trying again..."
-            sleep 10          
+            sleep 10        
 
       - name: Build and Test ${{ env.PACKAGE_NAME }}
         run: |

--- a/docker-images/build-images.sh
+++ b/docker-images/build-images.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 PROJ_ROOT=$(realpath "$SCRIPT_DIR/..")
 
 if [ -z "$OCI_EXE" ]; then
+    # Select which container exe to use based on which implementation is found on system `PATH`. The ordering below
+    # (podman, docker, finch) matches the ordering in the dockcross runner scripts generated below.
     if which podman >/dev/null 2>/dev/null; then
         OCI_EXE=podman
     elif which docker >/dev/null 2>/dev/null; then
@@ -26,6 +28,9 @@ if [ -z "$OCI_EXE" ]; then
 fi
 
 echo "using container executor OCI_EXE=$OCI_EXE"
+
+echo "Authenticating to Public ECR:"
+aws ecr-public get-login-password --region us-east-1 | $OCI_EXE login --username AWS --password-stdin public.ecr.aws
 
 if [ "$#" -gt 0 ]; then
   IMAGES=("$@")


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Attempts to improve the reliability of our Docker image build by:
* Authenticating to Public ECR before building images. In theory, this gets us a higher throttling limit.
* Adding a retry loop around the Docker image build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.