### PR TITLE
chore: relax sdk-version-check to only include the main branch, not feature branches

### DIFF
--- a/.github/workflows/sdk-version-check.yml
+++ b/.github/workflows/sdk-version-check.yml
@@ -8,7 +8,6 @@ on:
     types: [opened, synchronize, reopened, labeled]
     branches:
       - main
-      - '*-main'
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

The **sdk-version-check** workflow shouldn't include feature branches because our automatic merges from **main** _into_ feature branches will necessarily update the version in **gradle.properties**. We only need to check **main** since that's where the version number is most relevant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.